### PR TITLE
fix(oracle): add SKR/SEEKER to JUPITER_MINTS — unblocks SEEKER/USD market

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -370,6 +370,8 @@ const JUPITER_MINTS: Record<string, string> = {
   PYTH: "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3",
   RAY: "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
   RNDR: "rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof",
+  SKR: "SKRbvo6Gf7GondiT3BbTfuRDPqLWei4j2Qy2NPGZhW3",
+  SEEKER: "SKRbvo6Gf7GondiT3BbTfuRDPqLWei4j2Qy2NPGZhW3",
 };
 
 /** Batch-fetch prices from Pyth Hermes REST API */


### PR DESCRIPTION
## Problem

GH#1726 — SEEKER/USD market (`FPFcixRnhYDVY7wLVRTATVV1banRFefQAfX9Gn2LyoRY`) shows NO ORACLE amber badge. 

Root cause analysis:
- Slab has `oracleAuthority = FF7KFfU5...` which **matches** the keeper admin key ✅
- BUT collateral mint is `7KyVYJN...` (devnet-only) — not in JUPITER_MINTS or PYTH_FEED_IDS
- `getPrice('SKR'/'SEEKER', slab)` returns null on every tick → market never gets a price push
- On first push with null result and no lastPrice, keeper exits early → market stuck at NO ORACLE

## Fix

Add SKR (Seeker, `SKRbvo6Gf7GondiT3BbTfuRDPqLWei4j2Qy2NPGZhW3`) to `JUPITER_MINTS`:
- Both `SKR` and `SEEKER` keys added (market DB may use either symbol)
- DexScreener confirms live price ~$0.019 with active pairs
- Jupiter also prices it via the mainnet CA

## Companion change

**percolator-launch migration `20260326083400`** sets `mainnet_ca = 'SKRbvo6...'\ + `symbol='SKR'` on the markets row so `discoverNewMarkets()` picks it up via the CA fallback path too.

## Testing

After merge + Railway redeploy:
1. Oracle-keeper should log `✅ SEEKER/USD: $X.XX [jupiter] → sig...` within 10s
2. Market page should show live price badge instead of NO ORACLE
3. Trading should become unblocked

## Notes
- No Pyth feed exists for SKR — Jupiter/DexScreener price is the correct source
- Oracle authority verified on-chain: FF7KFfU5... = keeper admin key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended token support to include SKR and SEEKER symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->