### PR TITLE
fix: validate safety-critical numeric envs (fail-fast) — #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.json
 !package-lock.json
 !package.json
+!tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1028,13 +1028,6 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1360,6 +1353,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts",
     "dev": "tsx watch src/index.ts",
     "build": "tsc --noEmit",
-    "test": "tsx src/index.ts --help 2>/dev/null || true"
+    "test": "node --import tsx/esm --test src/env-validation.test.ts"
   },
   "dependencies": {
     "@percolator/sdk": "github:dcccrypto/percolator-sdk",

--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared environment-variable parsing utilities.
+ *
+ * Kept in a standalone module so unit tests can import the pure helper
+ * without triggering the oracle keeper's module-level side-effects
+ * (RPC connection, keypair load, etc.).
+ */
+
+/**
+ * Parse a safety-critical numeric environment variable.
+ *
+ * If the variable is unset or empty the fallback is used.
+ * If the resulting value is not a finite positive number the process throws
+ * immediately — a NaN/Infinity/zero/negative value would silently disable
+ * guards (e.g. circuit breaker always-false when MAX_PRICE_MOVE_PCT is NaN).
+ */
+export function parsePositiveNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const value = raw == null || raw.trim() === "" ? fallback : Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(
+      `${name} must be a finite positive number (got: ${JSON.stringify(raw)})`,
+    );
+  }
+  return value;
+}

--- a/src/env-validation.test.ts
+++ b/src/env-validation.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for parsePositiveNumberEnv (bounty finding #4 fix).
+ *
+ * Run with: node --import tsx/esm --test src/env-validation.test.ts
+ * Or via:   pnpm test
+ *
+ * Uses Node's built-in test runner (no extra deps — Node 20+ required,
+ * which matches engines.node in package.json).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parsePositiveNumberEnv } from "./env-utils.ts";
+
+// ── helpers ──────────────────────────────────────────────────
+
+function withEnv(key: string, value: string | undefined, fn: () => void) {
+  const prev = process.env[key];
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = prev;
+    }
+  }
+}
+
+// ── parsePositiveNumberEnv ────────────────────────────────────
+
+describe("parsePositiveNumberEnv", () => {
+
+  describe("valid inputs", () => {
+    it("uses fallback when env var is unset", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", undefined, () => {
+        const result = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10);
+        assert.equal(result, 10);
+      });
+    });
+
+    it("uses fallback when env var is empty string", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", "", () => {
+        const result = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10);
+        assert.equal(result, 10);
+      });
+    });
+
+    it("parses a valid integer value", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", "15", () => {
+        const result = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10);
+        assert.equal(result, 15);
+      });
+    });
+
+    it("parses a valid float value", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", "2.5", () => {
+        const result = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10);
+        assert.equal(result, 2.5);
+      });
+    });
+
+    it("uses fallback when env var is whitespace-only", () => {
+      withEnv("PUSH_INTERVAL_MS", "   ", () => {
+        const result = parsePositiveNumberEnv("PUSH_INTERVAL_MS", 3000);
+        assert.equal(result, 3000);
+      });
+    });
+  });
+
+  describe("invalid inputs — must throw (circuit-breaker NaN bypass fix)", () => {
+    it("throws on non-numeric string (e.g. 'abc')", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", "abc", () => {
+        assert.throws(
+          () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10),
+          /MAX_PRICE_MOVE_PCT must be a finite positive number/,
+        );
+      });
+    });
+
+    it("throws on 'NaN' literal", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", "NaN", () => {
+        assert.throws(
+          () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10),
+          /MAX_PRICE_MOVE_PCT must be a finite positive number/,
+        );
+      });
+    });
+
+    it("throws on 'Infinity' literal", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", "Infinity", () => {
+        assert.throws(
+          () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10),
+          /MAX_PRICE_MOVE_PCT must be a finite positive number/,
+        );
+      });
+    });
+
+    it("throws on zero (zero threshold disables the guard)", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", "0", () => {
+        assert.throws(
+          () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10),
+          /MAX_PRICE_MOVE_PCT must be a finite positive number/,
+        );
+      });
+    });
+
+    it("throws on negative number", () => {
+      withEnv("MAX_PRICE_MOVE_PCT", "-5", () => {
+        assert.throws(
+          () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10),
+          /MAX_PRICE_MOVE_PCT must be a finite positive number/,
+        );
+      });
+    });
+
+    it("throws on alphanumeric mix (e.g. '10abc')", () => {
+      withEnv("PUSH_INTERVAL_MS", "10abc", () => {
+        assert.throws(
+          () => parsePositiveNumberEnv("PUSH_INTERVAL_MS", 3000),
+          /PUSH_INTERVAL_MS must be a finite positive number/,
+        );
+      });
+    });
+  });
+
+  describe("circuit-breaker behavior with valid threshold", () => {
+    /**
+     * Simulate the circuit-breaker comparison to confirm that with a valid
+     * MAX_PRICE_MOVE_PCT=10, a 900% move would be rejected.
+     *
+     * We do not import checkCircuitBreaker (it's not exported) so we replicate
+     * the comparison logic inline — this is the exact expression from index.ts:557.
+     */
+    it("rejects a 900% price move when breaker is configured with threshold 10", () => {
+      const threshold = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10); // uses fallback = 10
+      const lastPrice = 100;
+      const newPrice = 1000; // +900%
+      const movePct = Math.abs((newPrice - lastPrice) / lastPrice) * 100; // 900
+      const rejected = movePct > threshold;
+      assert.ok(rejected, `Expected 900% move to be rejected (movePct=${movePct}, threshold=${threshold})`);
+    });
+
+    it("accepts a small move within the threshold", () => {
+      const threshold = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10);
+      const lastPrice = 100;
+      const newPrice = 105; // +5%
+      const movePct = Math.abs((newPrice - lastPrice) / lastPrice) * 100; // 5
+      const accepted = !(movePct > threshold);
+      assert.ok(accepted, `Expected 5% move to be accepted (movePct=${movePct}, threshold=${threshold})`);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,10 +44,12 @@ import * as fs from "fs";
 import * as http from "http";
 
 // ── Config ──────────────────────────────────────────────────
-const PUSH_INTERVAL_MS = Number(process.env.PUSH_INTERVAL_MS ?? "3000");
-const HEALTH_PORT = Number(process.env.HEALTH_PORT ?? "18810");
-const MAX_PRICE_MOVE_PCT = Number(process.env.MAX_PRICE_MOVE_PCT ?? "10");
-const STALE_THRESHOLD_S = Number(process.env.STALE_THRESHOLD_S ?? "30");
+import { parsePositiveNumberEnv } from "./env-utils.ts";
+
+const PUSH_INTERVAL_MS    = parsePositiveNumberEnv("PUSH_INTERVAL_MS",    3000);
+const HEALTH_PORT         = parsePositiveNumberEnv("HEALTH_PORT",         18810);
+const MAX_PRICE_MOVE_PCT  = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT",  10);
+const STALE_THRESHOLD_S   = parsePositiveNumberEnv("STALE_THRESHOLD_S",   30);
 /**
  * Blocked Markets - Markets that cannot be serviced by this oracle-keeper
  *
@@ -298,7 +300,7 @@ function validateEnvironmentConfig(): void {
 // ── Supabase Auto-Discovery ─────────────────────────────────
 const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
-const DISCOVERY_INTERVAL_MS = Number(process.env.DISCOVERY_INTERVAL_MS ?? "30000"); // 30s
+const DISCOVERY_INTERVAL_MS = parsePositiveNumberEnv("DISCOVERY_INTERVAL_MS", 30000); // 30s
 
 const supabaseEnabled = !!(SUPABASE_URL && SUPABASE_SERVICE_KEY);
 
@@ -520,13 +522,11 @@ let startTime = Date.now();
 // Devops audit 2026-03-14: wallet FF7KFfU5 exhausted twice in one day from
 // ~20+ markets per 3-second cycle. Guard prevents on-chain txn drain when
 // balance is low. Default: 0.05 SOL (50_000_000 lamports).
-const MIN_KEEPER_BALANCE_LAMPORTS = Number(
-  process.env.MIN_KEEPER_BALANCE_SOL
-    ? Math.round(parseFloat(process.env.MIN_KEEPER_BALANCE_SOL) * 1e9)
-    : 50_000_000,
-);
+const MIN_KEEPER_BALANCE_LAMPORTS = process.env.MIN_KEEPER_BALANCE_SOL
+  ? Math.round(parsePositiveNumberEnv("MIN_KEEPER_BALANCE_SOL", 0.05) * 1e9)
+  : 50_000_000;
 // Interval between balance refreshes (default: every 30 s = ~10 push cycles at 3s interval)
-const BALANCE_CHECK_INTERVAL_MS = Number(process.env.BALANCE_CHECK_INTERVAL_MS ?? "30000");
+const BALANCE_CHECK_INTERVAL_MS = parsePositiveNumberEnv("BALANCE_CHECK_INTERVAL_MS", 30000);
 let walletBalanceLamports: number | null = null;
 let lastBalanceCheckAt = 0;
 let walletLow = false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Verified finding by @Bayyan16.

`MAX_PRICE_MOVE_PCT` was parsed with a bare `Number(...)`; a non-numeric value (e.g. `abc`) became `NaN`, and `movePct > NaN` is always `false` → the oracle circuit breaker **failed open** and accepted extreme price moves (e.g. +900%) silently.

Fix: new `parsePositiveNumberEnv(name, fallback)` that throws on a non-finite/non-positive value. All six module-level numeric-env constants now use it (`MAX_PRICE_MOVE_PCT`, `PUSH_INTERVAL_MS`, `HEALTH_PORT`, `STALE_THRESHOLD_S`, `DISCOVERY_INTERVAL_MS`, `MIN_KEEPER_BALANCE_SOL`, `BALANCE_CHECK_INTERVAL_MS`). Because these are evaluated at import time, a malformed value now **fails fast at startup** rather than running with a disabled guard. 13 unit tests added (`node:test`); `tsc --noEmit` clean. Verified the parse sites are module-level (before `main()`).

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)