### PR TITLE
fix: key health markets by slab address

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -906,14 +906,14 @@ function startHealthServer() {
       const now = Date.now();
       const uptimeS = Math.floor((now - startTime) / 1000);
       const markets: Record<string, any> = {};
+      const marketsBySlab: Record<string, unknown> = {};
       let healthy = true;
 
       for (const [slab, s] of stats) {
         const staleSec = s.lastPushAt ? Math.floor((now - s.lastPushAt) / 1000) : -1;
         const isStale = staleSec > STALE_THRESHOLD_S;
         if (isStale) healthy = false;
-        markets[slab] = {
-          symbol: s.symbol,
+        const marketHealth = {
           lastPrice: s.lastPrice,
           lastPushAgo: `${staleSec}s`,
           stale: isStale,
@@ -922,6 +922,11 @@ function startHealthServer() {
           totalErrors: s.totalErrors,
           consecutiveErrors: s.consecutiveErrors,
           circuitBreakerTrips: s.circuitBreakerTrips,
+        };
+        markets[s.symbol] = marketHealth;
+        marketsBySlab[slab] = {
+          symbol: s.symbol,
+          ...marketHealth,
         };
       }
 
@@ -939,6 +944,7 @@ function startHealthServer() {
           low: walletLow,
         },
         markets,
+        marketsBySlab,
       }, null, 2);
 
       res.writeHead(healthy ? 200 : 503, { "Content-Type": "application/json" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -912,7 +912,8 @@ function startHealthServer() {
         const staleSec = s.lastPushAt ? Math.floor((now - s.lastPushAt) / 1000) : -1;
         const isStale = staleSec > STALE_THRESHOLD_S;
         if (isStale) healthy = false;
-        markets[s.symbol] = {
+        markets[slab] = {
+          symbol: s.symbol,
           lastPrice: s.lastPrice,
           lastPushAgo: `${staleSec}s`,
           stale: isStale,


### PR DESCRIPTION
## Summary

This PR fixes the `/health` endpoint so market health entries are keyed by slab address instead of market symbol.

Previously, the health response used `s.symbol` as the key for each market entry. If multiple slabs shared the same symbol, the later entry overwrote the previous one.

This caused the `/health` response to collapse multiple internal market stats into a single visible entry.

Closes #8

## Problem

Internal keeper stats are tracked per slab address:

```ts
const stats = new Map<string, MarketStats>();
```

However, the `/health` response was keyed by symbol:

```ts
markets[s.symbol] = {
  lastPrice: s.lastPrice,
  lastPushAgo: `${staleSec}s`,
  stale: isStale,
  source: s.source,
  totalPushes: s.totalPushes,
  totalErrors: s.totalErrors,
  consecutiveErrors: s.consecutiveErrors,
  circuitBreakerTrips: s.circuitBreakerTrips,
};
```

This means duplicate symbols overwrite each other.

For example:

* Slab A has `symbol = HYPERP`
* Slab B also has `symbol = HYPERP`
* Slab A is stale and has errors
* Slab B is healthy
* The `/health` response only shows one `HYPERP` entry
* The stale/error state from Slab A can be hidden by Slab B

This can make monitoring output misleading.

## Impact

The global health status can become `degraded`, but the visible market detail can still look healthy because the stale market entry was overwritten.

This affects operator visibility and monitoring accuracy, especially when multiple slabs share the same symbol.

This is relevant for HYPERP markets discovered through `oracle_markets`, where multiple discovered markets can share the same displayed symbol.

## Fix

This PR changes the health response to use the slab address as the object key:

```ts
markets[slab] = {
  symbol: s.symbol,
  lastPrice: s.lastPrice,
  lastPushAgo: `${staleSec}s`,
  stale: isStale,
  source: s.source,
  totalPushes: s.totalPushes,
  totalErrors: s.totalErrors,
  consecutiveErrors: s.consecutiveErrors,
  circuitBreakerTrips: s.circuitBreakerTrips,
};
```

The symbol is still included inside each market object, but the response key is now unique per slab.

## Changes

* Replaced `markets[s.symbol]` with `markets[slab]`
* Added `symbol: s.symbol` inside each market health object
* Preserved one `/health` entry per slab
* Prevented duplicate market symbols from overwriting each other

## Before

Duplicate symbols could collapse into one visible entry:

```json
{
  "status": "degraded",
  "markets": {
    "HYPERP": {
      "lastPrice": 1.24,
      "lastPushAgo": "0s",
      "stale": false,
      "source": "hyperp-dex"
    }
  }
}
```

In this case, the response only shows one `HYPERP` entry even though multiple slabs exist internally.

## After

Each slab is preserved as a separate health entry:

```json
{
  "status": "degraded",
  "markets": {
    "slab_stale_111111111111111111111111111111111": {
      "symbol": "HYPERP",
      "lastPrice": 1.23,
      "lastPushAgo": "120s",
      "stale": true,
      "source": "hyperp-dex"
    },
    "slab_healthy_22222222222222222222222222222222": {
      "symbol": "HYPERP",
      "lastPrice": 1.24,
      "lastPushAgo": "0s",
      "stale": false,
      "source": "hyperp-dex"
    }
  }
}
```

This makes the health response match the keeper's internal per-slab tracking model.

## Validation

Ran TypeScript check:

```bash
npx tsc --noEmit --target es2022 --module nodenext --moduleResolution nodenext --allowImportingTsExtensions --skipLibCheck src/index.ts
```

## Scope

This PR only changes the `/health` response keying behavior.

It does not modify:

* oracle price push logic
* keeper crank logic
* stale detection logic
* circuit breaker logic
* Supabase integration
* market discovery logic
* transaction building
* market stats update behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data loss in health status responses when multiple markets share the same symbol. All markets are now correctly preserved and individually accessible in the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->