### PR TITLE
fix: skip stale last-known oracle prices

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -352,6 +352,12 @@ interface MarketStats {
 
 // ── Price Sources ───────────────────────────────────────────
 
+type PriceResult = {
+  price: number;
+  source: string;
+  freshAt: number;
+};
+
 // Pyth Network feed IDs (hex, without 0x prefix) — universal across all chains
 const PYTH_FEED_IDS: Record<string, string> = {
   SOL: "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
@@ -438,12 +444,12 @@ async function fetchPythPrices(symbols: string[]): Promise<void> {
   }
 }
 
-function getPythPrice(symbol: string): number | null {
+function getPythPrice(symbol: string): { price: number; freshAt: number } | null {
   const cached = pythCache.get(symbol);
   if (!cached) return null;
   // Reject if older than 30s
   if (Date.now() - cached.ts > 30_000) return null;
-  return cached.price;
+  return { price: cached.price, freshAt: cached.ts };
 }
 
 /** Jupiter price fallback (uses mint addresses) */
@@ -481,18 +487,18 @@ async function fetchDexScreenerPrice(symbol: string): Promise<number | null> {
 }
 
 /** Fetch price with multi-source failover: Pyth → Jupiter → DexScreener → CA lookup */
-async function getPrice(symbol: string, slab?: string): Promise<{ price: number; source: string } | null> {
+async function getPrice(symbol: string, slab?: string): Promise<PriceResult | null> {
   // Primary: Pyth (decentralized oracle, fastest for supported tokens)
   const pyth = getPythPrice(symbol);
-  if (pyth) return { price: pyth, source: "pyth" };
+  if (pyth) return { price: pyth.price, source: "pyth", freshAt: pyth.freshAt };
 
   // Secondary: Jupiter (Solana DEX aggregator, uses mint addresses)
   const jup = await fetchJupiterPrice(symbol);
-  if (jup) return { price: jup, source: "jupiter" };
+  if (jup) return { price: jup, source: "jupiter", freshAt: Date.now() };
 
   // Tertiary: DexScreener (broad coverage for exotic tokens)
   const dex = await fetchDexScreenerPrice(symbol);
-  if (dex) return { price: dex, source: "dexscreener" };
+  if (dex) return { price: dex, source: "dexscreener", freshAt: Date.now() };
 
   // Quaternary: Direct CA lookup for dynamic markets (PERC-465)
   if (slab) {
@@ -708,10 +714,12 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
   // all live price sources fail.
   let price: number;
   let source: string;
+  let freshPriceAt: number | null = null;
 
   if (result && isPriceValid(result.price)) {
     price = result.price;
     source = result.source;
+    freshPriceAt = result.freshAt;
   } else if (s.lastPrice > 0) {
     // Devnet / transient no-pool fallback: reuse the last successfully pushed
     // live-source price only while it remains within the freshness threshold.
@@ -791,8 +799,8 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
 
   s.lastPrice = price;
   s.lastPushAt = Date.now();
-  if (source !== "last-known") {
-    s.lastFreshPriceAt = s.lastPushAt;
+  if (freshPriceAt !== null) {
+    s.lastFreshPriceAt = freshPriceAt;
   }
   s.lastPushSig = sig;
   s.totalPushes++;
@@ -1111,7 +1119,7 @@ async function discoverNewMarkets(): Promise<MarketInfo[]> {
  * since they may not be in PYTH_FEED_IDS or JUPITER_MINTS.
  * This fetches price directly using the mainnet CA via Jupiter Lite API.
  */
-async function fetchPriceByCA(mainnetCA: string): Promise<{ price: number; source: string } | null> {
+async function fetchPriceByCA(mainnetCA: string): Promise<PriceResult | null> {
   // Validate as base58 Solana address before using in external URLs (#783, #784)
   if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(mainnetCA)) return null;
   const encoded = encodeURIComponent(mainnetCA);
@@ -1125,7 +1133,7 @@ async function fetchPriceByCA(mainnetCA: string): Promise<{ price: number; sourc
     const data = json.data?.[mainnetCA];
     if (data?.price) {
       const p = parseFloat(data.price);
-      if (isFinite(p) && p > 0) return { price: p, source: "jupiter-ca" };
+      if (isFinite(p) && p > 0) return { price: p, source: "jupiter-ca", freshAt: Date.now() };
     }
   } catch {}
 
@@ -1139,7 +1147,7 @@ async function fetchPriceByCA(mainnetCA: string): Promise<{ price: number; sourc
     const pair = json.pairs?.[0];
     if (pair?.priceUsd) {
       const p = parseFloat(pair.priceUsd);
-      if (isFinite(p) && p > 0) return { price: p, source: "dexscreener-ca" };
+      if (isFinite(p) && p > 0) return { price: p, source: "dexscreener-ca", freshAt: Date.now() };
     }
   } catch {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -700,12 +700,10 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
 
   const result = await getPrice(market.symbol, market.slab);
 
-  // Resolve price: live source preferred, fall back to last known price when all
-  // external sources return null or zero (e.g. devnet token with no DEX pool).
-  // Without a fallback the on-chain oracle stays at 0, the UI freshness check marks
-  // the market "unavailable", and trading is blocked even though a valid price exists
-  // from a previous push.  This is safe: the circuit breaker below will still reject
-  // moves > MAX_PRICE_MOVE_PCT, and s.lastPrice is only set after a successful push.
+  // Resolve price: live source preferred. A last-known fallback is only allowed
+  // while the previous successful push is still within the freshness threshold.
+  // This avoids re-publishing stale cached prices with fresh oracle timestamps when
+  // all live price sources fail.
   let price: number;
   let source: string;
 
@@ -715,6 +713,17 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
   } else if (s.lastPrice > 0) {
     // Devnet / no-pool fallback: use last successfully pushed price to keep oracle alive.
     // Logged clearly so ops know the market is running on cached data.
+    const lastKnownAgeSec = s.lastPushAt
+      ? Math.floor((Date.now() - s.lastPushAt) / 1000)
+      : Infinity;
+
+    if (lastKnownAgeSec > STALE_THRESHOLD_S) {
+      s.totalErrors++;
+      s.consecutiveErrors++;
+      log(`No fresh price available for ${market.symbol}; last-known price is stale (${lastKnownAgeSec}s), skipping push`);
+      return;
+    }
+
     price = s.lastPrice;
     source = "last-known";
     if (!result) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,6 +341,7 @@ interface MarketStats {
   symbol: string;
   lastPrice: number;
   lastPushAt: number;       // epoch ms
+  lastFreshPriceAt: number;  // epoch ms of last successful live-source push
   lastPushSig: string;
   totalPushes: number;
   totalErrors: number;
@@ -538,6 +539,7 @@ function getOrCreateStats(market: MarketInfo): MarketStats {
       symbol: market.symbol,
       lastPrice: 0,
       lastPushAt: 0,
+      lastFreshPriceAt: 0,
       lastPushSig: "",
       totalPushes: 0,
       totalErrors: 0,
@@ -711,10 +713,10 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
     price = result.price;
     source = result.source;
   } else if (s.lastPrice > 0) {
-    // Devnet / no-pool fallback: use last successfully pushed price to keep oracle alive.
-    // Logged clearly so ops know the market is running on cached data.
-    const lastKnownAgeSec = s.lastPushAt
-      ? Math.floor((Date.now() - s.lastPushAt) / 1000)
+    // Devnet / transient no-pool fallback: reuse the last successfully pushed
+    // live-source price only while it remains within the freshness threshold.
+    const lastKnownAgeSec = s.lastFreshPriceAt
+      ? Math.floor((Date.now() - s.lastFreshPriceAt) / 1000)
       : Infinity;
 
     if (lastKnownAgeSec > STALE_THRESHOLD_S) {
@@ -789,6 +791,9 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
 
   s.lastPrice = price;
   s.lastPushAt = Date.now();
+  if (source !== "last-known") {
+    s.lastFreshPriceAt = s.lastPushAt;
+  }
   s.lastPushSig = sig;
   s.totalPushes++;
   s.consecutiveErrors = 0;


### PR DESCRIPTION
## Summary

This PR fixes a stale oracle freshness issue where the keeper could re-push a cached `last-known` price with a fresh oracle timestamp when all live price sources failed.

The fix keeps the existing `last-known` fallback behavior for short transient source outages, but prevents stale cached prices from being refreshed indefinitely.

Closes #10

## Problem

When live price fetching fails, the keeper can fall back to the last successfully pushed price:

```ts
} else if (s.lastPrice > 0) {
  price = s.lastPrice;
  source = "last-known";
}
```

The reused price is then pushed with a new timestamp:

```ts
const timestamp = BigInt(Math.floor(Date.now() / 1000));
```

After a successful push, `lastPushAt` is updated:

```ts
s.lastPushAt = Date.now();
```

This means a cached price can be re-published as if it were fresh.

A circuit breaker does not prevent this case because the reused `last-known` price has no price movement against itself.

## Root Cause

The keeper previously had only one freshness timestamp: `lastPushAt`.

That timestamp is updated after any successful push, including pushes that use `source = "last-known"`.

Because of that, using `lastPushAt` to decide whether the cached price is still fresh is not safe. A successful `last-known` fallback push can refresh `lastPushAt` and extend the life of cached data.

## Fix

This PR introduces a separate freshness marker for live-source prices:

```ts
lastFreshPriceAt
```

This value is updated only after a successful push from a live price source.

It is not updated when the keeper pushes `source = "last-known"`.

The `last-known` fallback now checks the age of the last successful live-source price:

```ts
const lastKnownAgeSec = s.lastFreshPriceAt
  ? Math.floor((Date.now() - s.lastFreshPriceAt) / 1000)
  : Infinity;
```

If the cached price is older than `STALE_THRESHOLD_S`, the keeper skips the push:

```ts
if (lastKnownAgeSec > STALE_THRESHOLD_S) {
  s.totalErrors++;
  s.consecutiveErrors++;
  log(`No fresh price available for ${market.symbol}; last-known price is stale (${lastKnownAgeSec}s), skipping push`);
  return;
}
```

## Changes

* Added `lastFreshPriceAt` to `MarketStats`
* Initialized `lastFreshPriceAt` for each market
* Changed `last-known` fallback freshness checks to use `lastFreshPriceAt`
* Prevented `last-known` pushes from refreshing live-source freshness
* Kept short-lived fallback behavior for transient live source failures
* Skipped stale cached price pushes once the previous live-source price exceeds `STALE_THRESHOLD_S`

## Before

If all live price sources failed, the keeper could continue using `s.lastPrice`.

A cached price could be pushed again with a new timestamp, and `lastPushAt` would be refreshed.

This could make stale oracle data appear current.

## After

The keeper only allows `last-known` fallback while the previous live-source price is still within the freshness threshold.

Once the live-source price is stale, the keeper skips the push instead of publishing stale data with a fresh timestamp.

## Validation

Ran TypeScript check:

```bash
npx tsc --noEmit --target es2022 --module nodenext --moduleResolution nodenext --allowImportingTsExtensions --skipLibCheck src/index.ts
```

## Scope

This PR only changes fallback behavior when live price sources fail.

It does not modify:

* live price source fetching
* oracle instruction encoding
* keeper crank logic
* circuit breaker logic
* transaction building
* market discovery
* health endpoint response shape
* Supabase integration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price update handling when live market data is unavailable or invalid.
  * The system now avoids using stale fallback prices indefinitely and will skip updates if no fresh price is available.
  * Successful live price updates now keep the freshness window accurate, reducing the chance of outdated pricing being pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->