### PR TITLE
fix: prefer CA pricing for dynamic markets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -479,8 +479,18 @@ async function fetchDexScreenerPrice(symbol: string): Promise<number | null> {
   } catch { return null; }
 }
 
-/** Fetch price with multi-source failover: Pyth → Jupiter → DexScreener → CA lookup */
+/** Fetch price with multi-source failover: CA lookup for mapped dynamic markets → Pyth → Jupiter → DexScreener */
 async function getPrice(symbol: string, slab?: string): Promise<{ price: number; source: string } | null> {
+  // Dynamic markets with a mainnet_ca mapping should use the CA as the
+  // authoritative asset identity before falling back to symbol-based sources.
+  if (slab) {
+    const ca = slabToMainnetCA.get(slab);
+    if (ca) {
+      const caPrice = await fetchPriceByCA(ca);
+      if (caPrice) return caPrice;
+    }
+  }
+
   // Primary: Pyth (decentralized oracle, fastest for supported tokens)
   const pyth = getPythPrice(symbol);
   if (pyth) return { price: pyth, source: "pyth" };
@@ -492,15 +502,6 @@ async function getPrice(symbol: string, slab?: string): Promise<{ price: number;
   // Tertiary: DexScreener (broad coverage for exotic tokens)
   const dex = await fetchDexScreenerPrice(symbol);
   if (dex) return { price: dex, source: "dexscreener" };
-
-  // Quaternary: Direct CA lookup for dynamic markets (PERC-465)
-  if (slab) {
-    const ca = slabToMainnetCA.get(slab);
-    if (ca) {
-      const caPrice = await fetchPriceByCA(ca);
-      if (caPrice) return caPrice;
-    }
-  }
 
   return null;
 }


### PR DESCRIPTION
## Summary

This PR fixes the price lookup priority for dynamic markets that have a `mainnet_ca` mapping.

For mapped dynamic markets, the keeper should use the mapped contract address (`mainnet_ca`) as the authoritative asset identity before falling back to symbol-based price sources.

Closes #12

## Problem

Previously, `getPrice(symbol, slab)` checked symbol-based price sources before checking the slab-to-`mainnet_ca` mapping.

The old lookup order was:

```ts
Pyth → Jupiter → DexScreener → CA lookup
```

This can be unsafe for dynamic markets.

If a dynamic market has a valid `mainnet_ca`, but its display `symbol` collides with another supported token symbol, the keeper can return the wrong asset price before CA-based lookup is attempted.

Example scenario:

1. A dynamic market is discovered with a slab address.
2. That slab maps to a `mainnet_ca` for token A.
3. The market symbol is set to `SOL`, or collides with another supported symbol.
4. `getPrice(symbol, slab)` checks Pyth/Jupiter/DexScreener by symbol first.
5. A symbol-based source returns the price for the symbol.
6. The CA lookup is never reached.
7. The dynamic market receives the wrong asset price.

## Impact

This is an oracle correctness issue.

For dynamic markets, `mainnet_ca` is a stronger asset identifier than the display symbol.

If a dynamic market receives a price from the wrong asset, it can affect downstream logic that relies on oracle values, including:

* trading
* margin logic
* liquidation logic
* settlement
* mark price calculation
* market health checks

This can become high impact if the pushed oracle price is consumed by live market logic.

## Root Cause

The previous price source priority treated symbol-based lookup as higher priority than CA-based lookup.

That may be acceptable for static markets where the symbol is intentionally mapped to known price sources.

However, for dynamic markets with a slab-to-`mainnet_ca` mapping, the contract address should be treated as the authoritative asset identity.

## Fix

This PR changes `getPrice()` so mapped dynamic markets attempt CA-based pricing first.

The new lookup order is:

```ts
CA lookup for mapped dynamic markets → Pyth → Jupiter → DexScreener
```

The updated logic is:

```ts
async function getPrice(symbol: string, slab?: string): Promise<{ price: number; source: string } | null> {
  // Dynamic markets with a mainnet_ca mapping should use the CA as the
  // authoritative asset identity before falling back to symbol-based sources.
  if (slab) {
    const ca = slabToMainnetCA.get(slab);
    if (ca) {
      const caPrice = await fetchPriceByCA(ca);
      if (caPrice) return caPrice;
    }
  }

  // Primary: Pyth
  const pyth = getPythPrice(symbol);
  if (pyth) return { price: pyth.price, source: "pyth" };

  // Secondary: Jupiter
  const jup = await fetchJupiterPrice(symbol);
  if (jup) return { price: jup, source: "jupiter" };

  // Tertiary: DexScreener
  const dex = await fetchDexScreenerPrice(symbol);
  if (dex) return { price: dex, source: "dexscreener" };

  return null;
}
```

## Changes

* Moved slab-to-`mainnet_ca` lookup to the top of `getPrice()`
* Treat `mainnet_ca` as the authoritative identity for mapped dynamic markets
* Keep symbol-based price sources as fallback when:

  * no slab is provided
  * no `mainnet_ca` mapping exists for the slab
  * CA-based pricing does not return a valid price
* Removed the lower-priority CA lookup block from the end of `getPrice()`
* Updated the price source order comment to match the new behavior

## Before

```ts
Pyth → Jupiter → DexScreener → CA lookup
```

A dynamic market with a symbol collision could receive a symbol-based price before CA lookup was attempted.

## After

```ts
CA lookup for mapped dynamic markets → Pyth → Jupiter → DexScreener
```

A dynamic market with a `mainnet_ca` mapping now attempts contract-address-based pricing first.

## Validation

Ran TypeScript check:

```bash
npx tsc --noEmit --target es2022 --module nodenext --moduleResolution nodenext --allowImportingTsExtensions --skipLibCheck src/index.ts
```

## Scope

This PR only changes price source precedence inside `getPrice()`.

It does not modify:

* transaction building
* oracle instruction encoding
* keeper crank logic
* circuit breaker logic
* stale price handling
* Supabase discovery
* market stats
* health endpoint response shape
* environment config parsing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Price checks for supported dynamic markets now use the mapped contract-address lookup first when available, improving quote selection.
* **Bug Fixes**
  * Updated the price source order so mapped market prices are found earlier instead of only as a last fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->