### PR TITLE
fix: update hyperp pool overrides

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -980,6 +980,16 @@ let markets: MarketInfo[] = [];
 // detect when they're disabled and downgrade them back to admin oracle mode.
 const hyperpFromOracleTable = new Set<string>();
 
+/**
+ * Discovers HYPERP markets from the Supabase oracle_markets table.
+ *
+ * This keeps already-tracked slabs synchronized with oracle_markets by:
+ * - upgrading non-HYPERP markets to HYPERP mode when an override is enabled
+ * - refreshing dexPoolAddress when an existing HYPERP pool override changes
+ * - invalidating cached HYPERP pool metadata after pool updates
+ *
+ * @returns Newly discovered HYPERP markets that should be added to the keeper.
+ */
 async function discoverHyperpFromOracleTable(): Promise<MarketInfo[]> {
   if (!supabaseEnabled) return [];
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1017,13 +1017,20 @@ async function discoverHyperpFromOracleTable(): Promise<MarketInfo[]> {
       if (!row.enabled || !row.slab_address || !row.dex_pool_address) continue;
 
       if (knownSlabs.has(row.slab_address)) {
-        // Upgrade an already-tracked market from admin/pyth → hyperp
+        // Upgrade an already-tracked market from admin/pyth → hyperp, or refresh
+        // the pool override when oracle_markets changes dex_pool_address.
         const existing = markets.find(m => m.slab === row.slab_address);
-        if (existing && existing.oracleMode !== "hyperp") {
-          log(`🔄 ${existing.label}: oracle_markets override → hyperp (pool=${row.dex_pool_address.slice(0, 12)}...)`);
-          existing.oracleMode = "hyperp";
-          existing.dexPoolAddress = row.dex_pool_address;
-          hyperpPoolCache.delete(row.slab_address); // force re-fetch with new pool
+        if (existing) {
+          if (existing.oracleMode !== "hyperp") {
+            log(`🔄 ${existing.label}: oracle_markets override → hyperp (pool=${row.dex_pool_address.slice(0, 12)}...)`);
+            existing.oracleMode = "hyperp";
+            existing.dexPoolAddress = row.dex_pool_address;
+            hyperpPoolCache.delete(row.slab_address); // force re-fetch with new pool
+          } else if (existing.dexPoolAddress !== row.dex_pool_address) {
+            log(`🔄 ${existing.label}: oracle_markets pool updated ${existing.dexPoolAddress?.slice(0, 12) ?? "none"}... → ${row.dex_pool_address.slice(0, 12)}...`);
+            existing.dexPoolAddress = row.dex_pool_address;
+            hyperpPoolCache.delete(row.slab_address); // invalidate stale pool metadata
+          }
         }
         hyperpFromOracleTable.add(row.slab_address);
         continue;


### PR DESCRIPTION
## Summary

This PR fixes HYPERP pool override handling for existing markets discovered from `oracle_markets`.

When an existing HYPERP market is already tracked by the keeper, updates to `oracle_markets.dex_pool_address` should also update the in-memory market configuration and invalidate the cached HYPERP pool metadata.

Closes #14

## Background

`oracle_markets` is used to configure HYPERP markets and their associated `dex_pool_address`.

The keeper already handles new HYPERP market discovery correctly. It also handles upgrading an already-tracked non-HYPERP market into HYPERP mode.

However, when a slab is already tracked and the market is already running with:

```ts
oracleMode === "hyperp"
```

the previous logic did not check whether `dex_pool_address` had changed in `oracle_markets`.

This means that if Supabase updates the pool address for an existing HYPERP market, the keeper can continue using the old pool address.

## Problem

Before this PR, the `knownSlabs.has(row.slab_address)` branch only handled this case:

```ts
if (existing && existing.oracleMode !== "hyperp") {
  existing.oracleMode = "hyperp";
  existing.dexPoolAddress = row.dex_pool_address;
  hyperpPoolCache.delete(row.slab_address);
}
```

This works when an existing non-HYPERP market is upgraded to HYPERP mode.

However, it does not handle this case:

```ts
existing.oracleMode === "hyperp"
existing.dexPoolAddress !== row.dex_pool_address
```

As a result:

1. `oracle_markets.dex_pool_address` can be updated in Supabase.
2. The keeper sees the slab is already known.
3. The market is already `hyperp`.
4. The new `dex_pool_address` is ignored.
5. `existing.dexPoolAddress` remains pointed to the old pool.
6. `hyperpPoolCache` is not invalidated.
7. The keeper can continue using stale cached pool metadata.

## Impact

This is an oracle correctness issue.

If a HYPERP market is migrated to a new pool, or if the previous pool becomes stale, deprecated, incorrect, or compromised, the keeper may continue using the old pool for HYPERP mark updates.

This can affect any downstream logic that depends on the HYPERP oracle mark price, including:

* trading
* margin logic
* liquidation logic
* settlement
* mark price calculation
* market health checks

## Root Cause

The existing logic only refreshed HYPERP configuration when the market was not already in HYPERP mode.

It did not compare the current in-memory `dexPoolAddress` against the latest `row.dex_pool_address` from `oracle_markets`.

Because of that, pool override changes for already-HYPERP markets were not applied.

## Fix

This PR keeps the existing upgrade behavior, but adds handling for existing HYPERP markets when the pool override changes.

Updated behavior:

```ts
if (existing) {
  if (existing.oracleMode !== "hyperp") {
    log(`🔄 ${existing.label}: oracle_markets override → hyperp (pool=${row.dex_pool_address.slice(0, 12)}...)`);
    existing.oracleMode = "hyperp";
    existing.dexPoolAddress = row.dex_pool_address;
    hyperpPoolCache.delete(row.slab_address); // force re-fetch with new pool
  } else if (existing.dexPoolAddress !== row.dex_pool_address) {
    log(`🔄 ${existing.label}: oracle_markets pool updated ${existing.dexPoolAddress?.slice(0, 12) ?? "none"}... → ${row.dex_pool_address.slice(0, 12)}...`);
    existing.dexPoolAddress = row.dex_pool_address;
    hyperpPoolCache.delete(row.slab_address); // invalidate stale pool metadata
  }
}
```

When `oracle_markets.dex_pool_address` changes for an existing HYPERP market, the keeper now:

1. detects the pool address change
2. updates `existing.dexPoolAddress`
3. invalidates `hyperpPoolCache` for that slab
4. logs the pool override update

## Changes

* Preserved existing admin/pyth → HYPERP upgrade behavior
* Added handling for existing HYPERP → HYPERP pool address changes
* Updated `existing.dexPoolAddress` when `oracle_markets.dex_pool_address` changes
* Invalidated cached HYPERP pool metadata when the pool address changes
* Added a log message for pool override updates
* Kept the change scoped to `discoverHyperpFromOracleTable()`

## Before

For an already-tracked HYPERP market:

```ts
existing.oracleMode === "hyperp"
existing.dexPoolAddress = oldPool
row.dex_pool_address = newPool
```

The keeper ignored the new pool address and continued using:

```ts
oldPool
```

The cached pool metadata could also remain active in:

```ts
hyperpPoolCache
```

## After

For an already-tracked HYPERP market:

```ts
existing.oracleMode === "hyperp"
existing.dexPoolAddress = oldPool
row.dex_pool_address = newPool
```

The keeper now updates the market config:

```ts
existing.dexPoolAddress = newPool
```

and clears stale cached pool metadata:

```ts
hyperpPoolCache.delete(row.slab_address)
```

This ensures the next HYPERP mark update uses the latest pool override from `oracle_markets`.

## Validation

Ran TypeScript check:

```bash
npx tsc --noEmit --target es2022 --module nodenext --moduleResolution nodenext --allowImportingTsExtensions --skipLibCheck src/index.ts
```

## Scope

This PR only changes HYPERP `oracle_markets` pool override refresh behavior.

It does not modify:

* transaction building
* HYPERP crank instruction encoding
* Supabase query shape
* new market registration
* disabled-market downgrade behavior
* price source lookup
* stale price handling
* circuit breaker logic
* market stats
* health endpoint response shape
* environment config parsing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of markets already marked as HYPERP so updated pool addresses are now recognized.
  * Cleared cached pool metadata when a pool address changes, ensuring the latest pool is used on the next update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->