### PR TITLE
fix: fail fast when Supabase-only discovery mode lacks PROGRAM_ID (vault#29)

### DIFF
--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -24,3 +24,30 @@ export function parsePositiveNumberEnv(name: string, fallback: number): number {
   }
   return value;
 }
+
+/**
+ * Validate that PROGRAM_ID is set when the oracle keeper is running in
+ * Supabase-only discovery mode (no deployment file, no DEPLOYMENT_JSON).
+ *
+ * Supabase discovery surfaces slab addresses, oracle modes, and pool addresses
+ * but does NOT supply a program id.  The keeper uses `programId` as a fallback
+ * when building instructions before a slab's on-chain owner has been cached.
+ * Without it, `new PublicKey(undefined)` throws the opaque "_bn" error from
+ * inside @solana/web3.js — crashing the service after it has already logged
+ * that Supabase-only mode is active (issue #29).
+ *
+ * @param programIdEnv - value of process.env.PROGRAM_ID (pass explicitly so
+ *   the function is a pure helper that tests can drive without touching the
+ *   real process.env).
+ * @throws Error with a clear diagnostic message when the id is absent.
+ */
+export function requireProgramIdForSupabaseMode(
+  programIdEnv: string | undefined,
+): void {
+  if (!programIdEnv || programIdEnv.trim() === "") {
+    throw new Error(
+      "PROGRAM_ID is required for Supabase-only discovery mode (no deployment file present). " +
+      "Set PROGRAM_ID to your deployed program's public key, or provide a deployment file / DEPLOYMENT_JSON.",
+    );
+  }
+}

--- a/src/env-validation.test.ts
+++ b/src/env-validation.test.ts
@@ -1,5 +1,9 @@
 /**
- * Unit tests for parsePositiveNumberEnv (bounty finding #4 fix).
+ * Unit tests for env-utils helpers.
+ *
+ * Covers:
+ *   - parsePositiveNumberEnv (bounty finding #4 fix)
+ *   - requireProgramIdForSupabaseMode (issue #29 fix)
  *
  * Run with: node --import tsx/esm --test src/env-validation.test.ts
  * Or via:   pnpm test
@@ -10,7 +14,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parsePositiveNumberEnv } from "./env-utils.ts";
+import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-utils.ts";
 
 // ── helpers ──────────────────────────────────────────────────
 
@@ -153,6 +157,74 @@ describe("parsePositiveNumberEnv", () => {
       const movePct = Math.abs((newPrice - lastPrice) / lastPrice) * 100; // 5
       const accepted = !(movePct > threshold);
       assert.ok(accepted, `Expected 5% move to be accepted (movePct=${movePct}, threshold=${threshold})`);
+    });
+  });
+});
+
+// ── requireProgramIdForSupabaseMode (issue #29 fix) ──────────────────────────
+
+/**
+ * These tests assert the fix for issue #29:
+ *
+ * In Supabase-only discovery mode (no deployment file, no DEPLOYMENT_JSON),
+ * the keeper built a fallback deploy object using `process.env.PROGRAM_ID`.
+ * When `PROGRAM_ID` was unset, `new PublicKey(undefined)` crashed the service
+ * with the opaque "_bn" error from @solana/web3.js — AFTER logging that
+ * Supabase-only mode was active.
+ *
+ * The fix (Option A): fail fast with a clear error before claiming
+ * Supabase-only mode is available.  `requireProgramIdForSupabaseMode` is the
+ * pure, testable helper that performs this check.
+ */
+describe("requireProgramIdForSupabaseMode (issue #29)", () => {
+
+  describe("throws a clear error when PROGRAM_ID is absent", () => {
+    it("throws when programId is undefined (env var unset)", () => {
+      assert.throws(
+        () => requireProgramIdForSupabaseMode(undefined),
+        /PROGRAM_ID is required for Supabase-only discovery mode/,
+      );
+    });
+
+    it("throws when programId is empty string", () => {
+      assert.throws(
+        () => requireProgramIdForSupabaseMode(""),
+        /PROGRAM_ID is required for Supabase-only discovery mode/,
+      );
+    });
+
+    it("throws when programId is whitespace-only", () => {
+      assert.throws(
+        () => requireProgramIdForSupabaseMode("   "),
+        /PROGRAM_ID is required for Supabase-only discovery mode/,
+      );
+    });
+
+    it("error message mentions the deployment file / DEPLOYMENT_JSON alternatives", () => {
+      let caught: Error | undefined;
+      try {
+        requireProgramIdForSupabaseMode(undefined);
+      } catch (e) {
+        caught = e as Error;
+      }
+      assert.ok(caught, "Expected an error to be thrown");
+      assert.match(caught.message, /DEPLOYMENT_JSON/);
+    });
+  });
+
+  describe("does NOT throw when PROGRAM_ID is present", () => {
+    it("succeeds with a valid-looking base58 public key", () => {
+      // Does not validate the key format — that is @solana/web3.js's job.
+      // We only check that the guard does not block a non-empty value.
+      assert.doesNotThrow(() =>
+        requireProgramIdForSupabaseMode("FwfBtNNUUEjFnX6BqNJKdgxHXKiU5KmTJq5vCHY5tqc"),
+      );
+    });
+
+    it("succeeds with any non-empty string (format validation is downstream)", () => {
+      assert.doesNotThrow(() =>
+        requireProgramIdForSupabaseMode("some-program-id"),
+      );
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ import * as fs from "fs";
 import * as http from "http";
 
 // ── Config ──────────────────────────────────────────────────
-import { parsePositiveNumberEnv } from "./env-utils.ts";
+import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-utils.ts";
 
 const PUSH_INTERVAL_MS    = parsePositiveNumberEnv("PUSH_INTERVAL_MS",    3000);
 const HEALTH_PORT         = parsePositiveNumberEnv("HEALTH_PORT",         18810);
@@ -1158,6 +1158,18 @@ async function main() {
     deployRaw = process.env.DEPLOYMENT_JSON;
   } else if (supabaseEnabled) {
     log("No deployment file — running in Supabase-only discovery mode");
+    // Guard: Supabase discovery cannot supply a program id from its market rows.
+    // The programId is needed as a fallback when building instructions for any
+    // market whose slab owner has not yet been cached.  Without it, the next
+    // line (`new PublicKey(deploy.programId)`) throws the opaque "_bn" error
+    // from inside @solana/web3.js, making the service crash after already
+    // claiming Supabase-only mode is active (issue #29).
+    try {
+      requireProgramIdForSupabaseMode(process.env.PROGRAM_ID);
+    } catch (e) {
+      console.error(`❌ ${(e as Error).message}`);
+      process.exit(1);
+    }
   } else {
     console.error("❌ Deployment info not found at", deployPath);
     console.error("   Run deploy-devnet-mm.ts first, set DEPLOYMENT_JSON env var, or set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.");


### PR DESCRIPTION
Fixes the bug reported in `percolator-vault#29` by @Bayyan16 — **mis-filed in the vault repo; the body + screenshot point at `percolator-oracle-keeper/src/index.ts`**, and the buggy code exists only here.

In Supabase-only discovery mode (no deployment file), the fallback built `{ programId: process.env.PROGRAM_ID, markets: [] }` then immediately did `new PublicKey(deploy.programId)`. With `PROGRAM_ID` unset, that threw the opaque `Cannot read properties of undefined (reading '_bn')` **after** logging that Supabase-only mode was active — the service died before any discovery cycle.

Fix (Option A — fail fast): new `requireProgramIdForSupabaseMode()` helper throws a clear, actionable message (and the service exits cleanly) before the `new PublicKey(...)` call. Option B (defer construction) was rejected after reading the discovery code: `discoverNewMarkets`/`discoverHyperpFromOracleTable` return only slab/symbol/oracle-mode/pool — they do **not** supply a program id, which is still needed as the per-market fallback, so Supabase-only mode genuinely requires `PROGRAM_ID`. Builds on the #4 env-validation helper merged in #6. 6 new tests; **19 pass**, `tsc` clean.

Resolves percolator-vault#29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)