### PR TITLE
fix(security): reject MAX_PRICE_MOVE_PCT ≥ 100 to prevent circuit-breaker bypass

### DIFF
--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -13,13 +13,22 @@
  * If the resulting value is not a finite positive number the process throws
  * immediately — a NaN/Infinity/zero/negative value would silently disable
  * guards (e.g. circuit breaker always-false when MAX_PRICE_MOVE_PCT is NaN).
+ *
+ * Pass `max` for percentage guards: a value ≥ max disables the guard entirely
+ * (e.g. MAX_PRICE_MOVE_PCT ≥ 100 means every price is accepted unconditionally).
  */
-export function parsePositiveNumberEnv(name: string, fallback: number): number {
+export function parsePositiveNumberEnv(name: string, fallback: number, max?: number): number {
   const raw = process.env[name];
   const value = raw == null || raw.trim() === "" ? fallback : Number(raw);
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error(
       `${name} must be a finite positive number (got: ${JSON.stringify(raw)})`,
+    );
+  }
+  if (max !== undefined && value >= max) {
+    throw new Error(
+      `${name} must be less than ${max} to keep the guard active (got: ${value}). ` +
+      `A value ≥ ${max} disables the circuit breaker unconditionally.`,
     );
   }
   return value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-u
 
 const PUSH_INTERVAL_MS    = parsePositiveNumberEnv("PUSH_INTERVAL_MS",    3000);
 const HEALTH_PORT         = parsePositiveNumberEnv("HEALTH_PORT",         18810);
-const MAX_PRICE_MOVE_PCT  = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT",  10);
+const MAX_PRICE_MOVE_PCT  = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT",  10,  100);
 const STALE_THRESHOLD_S   = parsePositiveNumberEnv("STALE_THRESHOLD_S",   30);
 /**
  * Blocked Markets - Markets that cannot be serviced by this oracle-keeper


### PR DESCRIPTION
## Summary

Closes #44.

- Adds optional `max` parameter to `parsePositiveNumberEnv` in `src/env-utils.ts`.
- Passes `max=100` for `MAX_PRICE_MOVE_PCT`: a value ≥ 100 would make the circuit-breaker condition `movePct > MAX_PRICE_MOVE_PCT` unreachable (all % values top out at ~100), silently disabling the guard.
- Process exits at startup with a clear diagnostic if the env var is out of range.

## Test plan

- [ ] `MAX_PRICE_MOVE_PCT=200` → process exits with `must be less than 100` error at startup
- [ ] `MAX_PRICE_MOVE_PCT=99` → process starts normally
- [ ] `MAX_PRICE_MOVE_PCT=0` → existing guard still rejects (non-positive)
- [ ] Unset `MAX_PRICE_MOVE_PCT` → fallback `10` accepted