### PR TITLE
fix(supply-chain): pin all deps to exact versions and enforce npm ci in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends git curl && \
 RUN groupadd -r keeper && useradd -r -g keeper -d /app keeper
 
 # Copy package files
-COPY package.json package-lock.json* ./
+COPY package.json package-lock.json ./
 
 # Install dependencies (includes tsx runtime)
-RUN npm install --omit=dev
+# npm ci enforces package-lock.json — prevents silent dep upgrades at build time
+RUN npm ci --omit=dev
 
 # Copy source
 COPY src/ src/

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "test": "node --import tsx/esm --test src/env-validation.test.ts"
   },
   "dependencies": {
-    "@percolator/sdk": "github:dcccrypto/percolator-sdk",
-    "@solana/web3.js": "^1.98.4",
-    "tsx": "^4.19.1"
+    "@percolator/sdk": "github:dcccrypto/percolator-sdk#f137aef5188e",
+    "@solana/web3.js": "1.98.4",
+    "tsx": "4.19.1"
   },
   "devDependencies": {
-    "@types/node": "^20.17.10",
-    "typescript": "^5.9.3"
+    "@types/node": "20.17.10",
+    "typescript": "5.9.3"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

Closes #48.

- Pins `@percolator/sdk` to upstream commit `f137aef5188e` (current main HEAD at time of audit).
- Pins `@solana/web3.js`, `tsx`, `@types/node`, and `typescript` to exact versions (no caret or tilde).
- Changes Dockerfile from `npm install` to `npm ci` so the lock file is always enforced during container builds.
- Changes `COPY package.json package-lock.json* ./` to `COPY package.json package-lock.json ./` — the glob silently succeeds even if `package-lock.json` is absent, allowing `npm ci` to fall back to a fresh install.

## Test plan

- [ ] `docker build .` succeeds with the pinned lock file present
- [ ] Removing `package-lock.json` causes `docker build` to fail with `npm ci` error (expected)
- [ ] `npm install` on developer machine regenerates a lock file with the same exact versions
- [ ] `@percolator/sdk` installs from the specified commit, not from the branch HEAD