### PR TITLE
fix(security): validate ORACLE_KEEPER_BLOCKED_MARKETS pubkeys at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,10 +88,32 @@ const HARDCODED_BLOCKED_MARKETS = new Set<string>([
  *
  * Both are merged at startup. Use environment variable for emergency blocks
  * without redeploying. Use hardcoded for permanent blocks.
+ *
+ * Each environment-supplied address is validated as a valid base58 pubkey at
+ * startup. An invalid address would silently become a Set entry that never
+ * matches any real slab, leaving the intended block unenforced.
  */
+const _envBlockedRaw = (process.env.ORACLE_KEEPER_BLOCKED_MARKETS ?? "")
+  .split(",")
+  .map(s => s.trim())
+  .filter(Boolean);
+
+for (const addr of _envBlockedRaw) {
+  try {
+    new PublicKey(addr);
+  } catch {
+    console.error(
+      `[FATAL] ORACLE_KEEPER_BLOCKED_MARKETS contains invalid base58 pubkey: "${addr}". ` +
+      "Invalid addresses are silently ignored at runtime, leaving the block unenforced. " +
+      "Correct the address or remove it from ORACLE_KEEPER_BLOCKED_MARKETS.",
+    );
+    process.exit(1);
+  }
+}
+
 const ORACLE_KEEPER_BLOCKED_MARKETS = new Set<string>([
   ...HARDCODED_BLOCKED_MARKETS,
-  ...(process.env.ORACLE_KEEPER_BLOCKED_MARKETS ?? "").split(",").map(s => s.trim()).filter(Boolean),
+  ..._envBlockedRaw,
 ]);
 const ADMIN_KP_PATH = process.env.ADMIN_KEYPAIR_PATH ??
   `${process.env.HOME}/.config/solana/percolator-upgrade-authority.json`;


### PR DESCRIPTION
## Summary

Closes #50.

- Parses `ORACLE_KEEPER_BLOCKED_MARKETS` entries into a validated list before constructing the Set.
- Each address is passed through `new PublicKey(addr)`; an invalid base58 string causes a fatal startup error with a clear message identifying the offending value.
- Valid addresses are inserted into the Set as before — no runtime behavior change for correct input.

## Test plan

- [ ] `ORACLE_KEEPER_BLOCKED_MARKETS=not-a-pubkey` → process exits with `[FATAL] invalid base58 pubkey` message
- [ ] `ORACLE_KEEPER_BLOCKED_MARKETS=HjBePQZnoZVftg9B52gyeuHGjBvt2f8FNCVP4FeoP3YT` → accepted, market blocked
- [ ] Empty env var or unset → Set contains only hardcoded entries, no error
- [ ] Multiple comma-separated valid addresses → all accepted
- [ ] Mix of valid + one invalid → exits on invalid, does not proceed with partial block list