### PR TITLE
fix(oracle-keeper): un-wedge circuit breaker on confirmed price relocation (#30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts",
     "dev": "tsx watch src/index.ts",
     "build": "tsc --noEmit",
-    "test": "node --import tsx/esm --test src/env-validation.test.ts"
+    "test": "node --import tsx/esm --test src/env-validation.test.ts src/circuit-breaker.test.ts"
   },
   "dependencies": {
     "@percolator/sdk": "github:dcccrypto/percolator-sdk#b6daec0de445e252bb28eb80891212d7c2a31659",

--- a/src/circuit-breaker.test.ts
+++ b/src/circuit-breaker.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for the circuit-breaker helper (issue #30 fix).
+ *
+ * Covers:
+ *   - Normal within-threshold prices are accepted.
+ *   - A single spike is blocked and does NOT re-baseline lastPrice.
+ *   - A spike that disappears (price returns to normal) resets the run
+ *     counter so the spike can never accumulate to confirmation.
+ *   - A sustained, consistent relocation accumulates trips and is accepted
+ *     (re-baselined) after CONFIRM_TRIPS consecutive trips.
+ *   - A run of inconsistent spikes (each at a different level) never confirms.
+ *   - First price (lastPrice === 0) is always accepted regardless of value.
+ *   - confirmTrips boundary: accepted on exactly the Nth trip, not the N-1th.
+ *
+ * Run with: node --import tsx/esm --test src/circuit-breaker.test.ts
+ * Or via:   pnpm test
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { checkCircuitBreaker } from "./circuit-breaker.ts";
+import type { CircuitBreakerState } from "./circuit-breaker.ts";
+
+// ── helpers ──────────────────────────────────────────────────
+
+/** Build a fresh state with a given baseline price. */
+function makeState(lastPrice = 100, symbol = "TEST"): CircuitBreakerState {
+  return {
+    symbol,
+    lastPrice,
+    circuitBreakerTrips: 0,
+    cbTripPrice: 0,
+    cbConsecutiveTrips: 0,
+  };
+}
+
+/** Silent log sink for tests. */
+const silent = () => {};
+
+/** Standard 10% threshold, 3 confirmations. */
+const cfg = { maxMovePct: 10, confirmTrips: 3, log: silent };
+
+// ── first-price bootstrap ─────────────────────────────────────
+
+describe("first price (lastPrice === 0)", () => {
+  it("always accepts any first price", () => {
+    const s = makeState(0);
+    assert.ok(checkCircuitBreaker(s, 999_999, cfg));
+    assert.equal(s.circuitBreakerTrips, 0);
+  });
+});
+
+// ── within-threshold prices ───────────────────────────────────
+
+describe("within-threshold prices", () => {
+  it("accepts a small positive move", () => {
+    const s = makeState(100);
+    assert.ok(checkCircuitBreaker(s, 105, cfg)); // 5% — within 10%
+    assert.equal(s.cbConsecutiveTrips, 0);
+  });
+
+  it("accepts a small negative move", () => {
+    const s = makeState(100);
+    assert.ok(checkCircuitBreaker(s, 95, cfg)); // 5% down
+  });
+
+  it("accepts exactly at the threshold boundary", () => {
+    const s = makeState(100);
+    assert.ok(checkCircuitBreaker(s, 110, cfg)); // exactly 10% — within (≤)
+  });
+
+  it("resets cbConsecutiveTrips when a normal price follows a partial run", () => {
+    const s = makeState(100);
+    // Two trips at a high level
+    checkCircuitBreaker(s, 120, cfg);
+    checkCircuitBreaker(s, 121, cfg);
+    assert.equal(s.cbConsecutiveTrips, 2);
+    // Normal price — must reset the counter
+    checkCircuitBreaker(s, 102, cfg);
+    assert.equal(s.cbConsecutiveTrips, 0);
+    assert.equal(s.cbTripPrice, 0);
+  });
+});
+
+// ── single-spike blocking ─────────────────────────────────────
+
+describe("single spike — must be blocked and NOT re-baseline", () => {
+  it("blocks a >threshold spike", () => {
+    const s = makeState(100);
+    const accepted = checkCircuitBreaker(s, 120, cfg); // 20% spike
+    assert.equal(accepted, false);
+  });
+
+  it("does NOT update lastPrice on a blocked spike", () => {
+    const s = makeState(100);
+    checkCircuitBreaker(s, 120, cfg);
+    assert.equal(s.lastPrice, 100); // baseline must be unchanged
+  });
+
+  it("increments circuitBreakerTrips on a blocked spike", () => {
+    const s = makeState(100);
+    checkCircuitBreaker(s, 120, cfg);
+    assert.equal(s.circuitBreakerTrips, 1);
+  });
+
+  it("the spike that disappears (price returns to normal) resets the counter", () => {
+    const s = makeState(100);
+    // Trip 1
+    checkCircuitBreaker(s, 120, cfg);
+    assert.equal(s.cbConsecutiveTrips, 1);
+    // Price returns to normal — resets the run
+    checkCircuitBreaker(s, 102, cfg);
+    assert.equal(s.cbConsecutiveTrips, 0);
+    assert.equal(s.lastPrice, 100); // baseline unchanged
+  });
+
+  it("a spike that recurs only once (1 trip then normal) never reaches confirmTrips=3", () => {
+    const s = makeState(100);
+    checkCircuitBreaker(s, 120, cfg); // trip 1
+    checkCircuitBreaker(s, 102, cfg); // normal — resets counter
+    checkCircuitBreaker(s, 120, cfg); // trip 1 again (new run)
+    assert.equal(s.cbConsecutiveTrips, 1);
+    assert.equal(s.lastPrice, 100);
+  });
+});
+
+// ── sustained relocation — wedge fix ─────────────────────────
+
+describe("sustained relocation — un-wedge after confirmTrips (issue #30)", () => {
+  it("blocks the first (confirmTrips - 1) trips", () => {
+    const s = makeState(100);
+    const r1 = checkCircuitBreaker(s, 120, cfg);
+    const r2 = checkCircuitBreaker(s, 121, cfg);
+    assert.equal(r1, false);
+    assert.equal(r2, false);
+    assert.equal(s.lastPrice, 100); // not yet re-baselined
+  });
+
+  it("accepts on the Nth (= confirmTrips) consecutive consistent trip and re-baselines", () => {
+    const s = makeState(100);
+    checkCircuitBreaker(s, 120, cfg); // trip 1 — blocked
+    checkCircuitBreaker(s, 121, cfg); // trip 2 — blocked
+    const r3 = checkCircuitBreaker(s, 119, cfg); // trip 3 — confirmed
+    assert.ok(r3, "3rd consistent trip must be accepted (relocation confirmed)");
+    assert.ok(
+      s.lastPrice >= 115 && s.lastPrice <= 125,
+      `lastPrice must re-baseline near 120, got ${s.lastPrice}`,
+    );
+  });
+
+  it("re-baselines to the confirming price, not the original", () => {
+    const s = makeState(100);
+    checkCircuitBreaker(s, 120, cfg);
+    checkCircuitBreaker(s, 121, cfg);
+    checkCircuitBreaker(s, 119, cfg); // confirms
+    // After confirmation, subsequent pushes near 120 must be accepted without tripping
+    const r4 = checkCircuitBreaker(s, 122, cfg);
+    assert.ok(r4, "push near new baseline must be accepted");
+    assert.equal(s.circuitBreakerTrips, 3); // no new trip
+  });
+
+  it("resets cbConsecutiveTrips and cbTripPrice after confirmation", () => {
+    const s = makeState(100);
+    checkCircuitBreaker(s, 120, cfg);
+    checkCircuitBreaker(s, 121, cfg);
+    checkCircuitBreaker(s, 119, cfg); // confirms
+    assert.equal(s.cbConsecutiveTrips, 0);
+    assert.equal(s.cbTripPrice, 0);
+  });
+
+  it("N-1 trips are not enough — the Nth trip is needed", () => {
+    const s = makeState(100);
+    // confirmTrips = 3, so 2 trips must not confirm
+    checkCircuitBreaker(s, 120, cfg);
+    const r2 = checkCircuitBreaker(s, 121, cfg);
+    assert.equal(r2, false, "2nd trip must still be blocked (confirmTrips=3 not reached)");
+    assert.equal(s.lastPrice, 100);
+  });
+});
+
+// ── inconsistent spikes never confirm ────────────────────────
+
+describe("inconsistent spikes — each at a different level, never confirm", () => {
+  it("a run of different-level spikes resets each time and never confirms", () => {
+    const s = makeState(100);
+    // Each spike is far from the previous one — they break each other's run.
+    checkCircuitBreaker(s, 120, cfg); // run starts at 120, cbConsecutive=1
+    checkCircuitBreaker(s, 200, cfg); // >10% from 120 — new run at 200, cbConsecutive=1
+    checkCircuitBreaker(s, 300, cfg); // >10% from 200 — new run at 300, cbConsecutive=1
+    // Despite 3 trips, no run ever reached confirmTrips
+    assert.equal(s.lastPrice, 100, "lastPrice must remain at original baseline");
+    assert.equal(s.circuitBreakerTrips, 3);
+  });
+});
+
+// ── confirmTrips = 1 edge case ────────────────────────────────
+
+describe("confirmTrips = 1 (instant re-baseline on first trip)", () => {
+  it("accepts the very first tripping price with confirmTrips=1", () => {
+    const s = makeState(100);
+    const r = checkCircuitBreaker(s, 120, { maxMovePct: 10, confirmTrips: 1, log: silent });
+    assert.ok(r, "confirmTrips=1 — first trip should immediately re-baseline");
+    assert.ok(s.lastPrice >= 115 && s.lastPrice <= 125);
+  });
+});

--- a/src/circuit-breaker.ts
+++ b/src/circuit-breaker.ts
@@ -1,0 +1,111 @@
+/**
+ * Circuit-breaker logic for the oracle keeper.
+ *
+ * Kept in a standalone module so unit tests can import the pure helpers
+ * without triggering the oracle keeper's module-level side-effects
+ * (RPC connection, keypair load, etc.).
+ *
+ * Issue #30 fix: a genuine, sustained price relocation (the same new level
+ * arriving on CONFIRM_TRIPS successive push cycles) is accepted and
+ * re-baselined rather than wedging the market permanently until restart.
+ */
+
+/** Subset of MarketStats fields that the circuit-breaker needs to read/write. */
+export interface CircuitBreakerState {
+  symbol: string;
+  lastPrice: number;
+  circuitBreakerTrips: number;
+  /** Price at the first trip in the current consecutive-trip run. */
+  cbTripPrice: number;
+  /** How many consecutive trips have occurred near cbTripPrice. */
+  cbConsecutiveTrips: number;
+}
+
+export interface CircuitBreakerConfig {
+  /** Reject moves larger than this percentage (e.g. 10 = 10%). */
+  maxMovePct: number;
+  /**
+   * Number of consecutive trips at a consistent new price level before the
+   * breaker re-baselines (accepting the relocation).  Must be ≥ 1.
+   */
+  confirmTrips: number;
+  /** Optional log sink — defaults to console.log. */
+  log?: (msg: string) => void;
+}
+
+/**
+ * Returns true if the price should be accepted for an on-chain push,
+ * false if it should be blocked.
+ *
+ * Mutates `state` to track trip counts and to re-baseline lastPrice when a
+ * sustained relocation is confirmed.
+ *
+ * Relocation recovery (issue #30):
+ *   A one-off spike is blocked every time it arrives (the next push at the
+ *   normal level resets cbConsecutiveTrips, so the spike can never accumulate
+ *   to confirmTrips).  A genuine, sustained relocation — where the same
+ *   approximate new price keeps arriving on successive push cycles without
+ *   itself varying by more than maxMovePct — is accepted after confirmTrips
+ *   consecutive trips and lastPrice is re-baselined so subsequent pushes at
+ *   that new level are no longer blocked.
+ */
+export function checkCircuitBreaker(
+  state: CircuitBreakerState,
+  newPrice: number,
+  cfg: CircuitBreakerConfig,
+): boolean {
+  const emit = cfg.log ?? console.log;
+
+  if (state.lastPrice === 0) return true; // First price — always accept.
+
+  const movePct =
+    Math.abs((newPrice - state.lastPrice) / state.lastPrice) * 100;
+
+  if (movePct <= cfg.maxMovePct) {
+    // Within threshold — reset the consecutive-trip counter and accept.
+    state.cbConsecutiveTrips = 0;
+    state.cbTripPrice = 0;
+    return true;
+  }
+
+  // Price exceeds the breaker threshold.
+  state.circuitBreakerTrips++;
+
+  // Determine whether this trip clusters near the ongoing run.
+  const tripPriceConsistent =
+    state.cbTripPrice > 0 &&
+    Math.abs((newPrice - state.cbTripPrice) / state.cbTripPrice) * 100 <=
+      cfg.maxMovePct;
+
+  if (tripPriceConsistent) {
+    // Same approximate level — advance the run.
+    state.cbConsecutiveTrips++;
+  } else {
+    // Different level (or first trip in run) — start a new run.
+    state.cbConsecutiveTrips = 1;
+    state.cbTripPrice = newPrice;
+  }
+
+  if (state.cbConsecutiveTrips >= cfg.confirmTrips) {
+    // Sustained relocation confirmed: re-baseline and accept.
+    emit(
+      `🟡 ${state.symbol}: Circuit breaker relocation confirmed after ` +
+        `${state.cbConsecutiveTrips} trips — re-baselining ` +
+        `${state.lastPrice.toFixed(2)} → ${newPrice.toFixed(2)} ` +
+        `(${movePct.toFixed(1)}% move)`,
+    );
+    state.lastPrice = newPrice;
+    state.cbConsecutiveTrips = 0;
+    state.cbTripPrice = 0;
+    return true;
+  }
+
+  // Not yet confirmed — block this push.
+  emit(
+    `🔴 ${state.symbol}: Circuit breaker! ` +
+      `${state.lastPrice.toFixed(2)} → ${newPrice.toFixed(2)} ` +
+      `(${movePct.toFixed(1)}% > ${cfg.maxMovePct}%) ` +
+      `[${state.cbConsecutiveTrips}/${cfg.confirmTrips} confirmation trips]`,
+  );
+  return false;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,11 +46,27 @@ import * as http from "http";
 
 // ── Config ──────────────────────────────────────────────────
 import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-utils.ts";
+import { checkCircuitBreaker as _checkCircuitBreaker } from "./circuit-breaker.ts";
+import type { CircuitBreakerState } from "./circuit-breaker.ts";
 
 const PUSH_INTERVAL_MS    = parsePositiveNumberEnv("PUSH_INTERVAL_MS",    3000);
 const HEALTH_PORT         = parsePositiveNumberEnv("HEALTH_PORT",         18810);
 const MAX_PRICE_MOVE_PCT  = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT",  10);
 const STALE_THRESHOLD_S   = parsePositiveNumberEnv("STALE_THRESHOLD_S",   30);
+/**
+ * Number of consecutive circuit-breaker trips at a consistent new price level
+ * required before the breaker re-baselines to that level (issue #30 fix).
+ *
+ * A one-off spike is rejected every time (the next normal push resets the
+ * counter).  A genuine, sustained relocation — where the same approximate
+ * price level arrives on CIRCUIT_BREAKER_CONFIRM_TRIPS successive push cycles
+ * without itself varying by more than MAX_PRICE_MOVE_PCT from the first
+ * tripping price — is accepted and re-baselines lastPrice, un-wedging the
+ * market without a process restart.
+ *
+ * Set via env var CIRCUIT_BREAKER_CONFIRM_TRIPS (must be ≥ 1, default 3).
+ */
+const CIRCUIT_BREAKER_CONFIRM_TRIPS = parsePositiveNumberEnv("CIRCUIT_BREAKER_CONFIRM_TRIPS", 3);
 /**
  * Blocked Markets - Markets that cannot be serviced by this oracle-keeper
  *
@@ -421,6 +437,10 @@ interface MarketStats {
   consecutiveErrors: number;
   circuitBreakerTrips: number;
   source: string;           // last successful source
+  /** Price of the first trip in the current consecutive-trip run (issue #30). */
+  cbTripPrice: number;
+  /** How many consecutive trips have occurred near cbTripPrice (issue #30). */
+  cbConsecutiveTrips: number;
 }
 
 // ── Price Sources ───────────────────────────────────────────
@@ -651,6 +671,8 @@ function getOrCreateStats(market: MarketInfo): MarketStats {
       consecutiveErrors: 0,
       circuitBreakerTrips: 0,
       source: "",
+      cbTripPrice: 0,
+      cbConsecutiveTrips: 0,
     };
     stats.set(market.slab, s);
   }
@@ -658,15 +680,17 @@ function getOrCreateStats(market: MarketInfo): MarketStats {
 }
 
 // ── Circuit Breaker ─────────────────────────────────────────
-function checkCircuitBreaker(stats: MarketStats, newPrice: number): boolean {
-  if (stats.lastPrice === 0) return true; // First price, always accept
-  const movePct = Math.abs((newPrice - stats.lastPrice) / stats.lastPrice) * 100;
-  if (movePct > MAX_PRICE_MOVE_PCT) {
-    log(`🔴 ${stats.symbol}: Circuit breaker! ${stats.lastPrice.toFixed(2)} → ${newPrice.toFixed(2)} (${movePct.toFixed(1)}% > ${MAX_PRICE_MOVE_PCT}%)`);
-    stats.circuitBreakerTrips++;
-    return false;
-  }
-  return true;
+/**
+ * Thin wrapper that binds the module-level config constants and log function
+ * to the pure checkCircuitBreaker helper from ./circuit-breaker.ts.
+ * See that module for full doc + issue #30 relocation-recovery semantics.
+ */
+function checkCircuitBreaker(s: MarketStats, newPrice: number): boolean {
+  return _checkCircuitBreaker(s as CircuitBreakerState, newPrice, {
+    maxMovePct: MAX_PRICE_MOVE_PCT,
+    confirmTrips: CIRCUIT_BREAKER_CONFIRM_TRIPS,
+    log,
+  });
 }
 
 // ── Logging ─────────────────────────────────────────────────
@@ -1056,6 +1080,7 @@ function startHealthServer() {
           totalErrors: s.totalErrors,
           consecutiveErrors: s.consecutiveErrors,
           circuitBreakerTrips: s.circuitBreakerTrips,
+          cbConsecutiveTrips: s.cbConsecutiveTrips,
         };
         markets[s.symbol] = marketHealth;
         marketsBySlab[slab] = {


### PR DESCRIPTION
Verified finding by the bounty reporter. The circuit breaker left `lastPrice` unchanged on a trip, so a legitimate >threshold price relocation kept tripping forever → the market's oracle was permanently wedged until process restart.

Fix: consecutive-trip confirmation. A single anomalous spike stays blocked (any in-threshold push resets the run counter; a bouncing/inconsistent spike can never accumulate). Only after `CIRCUIT_BREAKER_CONFIRM_TRIPS` (default 3) consecutive trips clustered at a consistent new level does it re-baseline `lastPrice` and accept — recovering without a restart. Verified by hand: one-off and bouncing spikes never re-baseline; sustained relocation un-wedges after N cycles. Extracted to a pure `circuit-breaker.ts` with 17 unit tests; 36 tests pass. oracle-keeper does not auto-deploy.

Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more robust price-movement protection that can confirm sustained spikes before accepting a new baseline.
  * Exposed additional circuit-breaker status in health reporting for better visibility.

* **Bug Fixes**
  * Improved handling of repeated price spikes so valid movements are not rejected after a sustained shift.
  * Added test coverage for edge cases, including threshold boundaries and confirmation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->