### PR TITLE
fix(oracle-keeper): security wave — 4 CRITICAL + hardening (#31/#32/#33/#34/#35/#36/#37/#44/#46/#48/#50)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@percolator/sdk": "github:dcccrypto/percolator-sdk#b6daec0de445e252bb28eb80891212d7c2a31659",
-        "@solana/web3.js": "^1.98.4",
-        "tsx": "^4.19.1"
+        "@solana/web3.js": "1.98.4",
+        "tsx": "4.19.1"
       },
       "devDependencies": {
         "@types/node": "^20.17.10",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
       "cpu": [
         "ppc64"
       ],
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
       "cpu": [
         "arm"
       ],
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
       "cpu": [
         "x64"
       ],
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
       "cpu": [
         "arm64"
       ],
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
       "cpu": [
         "x64"
       ],
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
       "cpu": [
         "arm64"
       ],
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
       "cpu": [
         "x64"
       ],
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
       "cpu": [
         "arm"
       ],
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
       "cpu": [
         "arm64"
       ],
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
       "cpu": [
         "ia32"
       ],
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
       "cpu": [
         "loong64"
       ],
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
       "cpu": [
         "mips64el"
       ],
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
       "cpu": [
         "ppc64"
       ],
@@ -254,9 +254,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
       "cpu": [
         "riscv64"
       ],
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
       "cpu": [
         "s390x"
       ],
@@ -286,9 +286,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
       "cpu": [
         "x64"
       ],
@@ -301,26 +301,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
       "cpu": [
         "x64"
       ],
@@ -334,9 +318,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
       "cpu": [
         "arm64"
       ],
@@ -350,9 +334,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
       "cpu": [
         "x64"
       ],
@@ -365,26 +349,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
       "cpu": [
         "x64"
       ],
@@ -398,9 +366,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
       "cpu": [
         "arm64"
       ],
@@ -414,9 +382,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
       "cpu": [
         "ia32"
       ],
@@ -430,9 +398,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
       "cpu": [
         "x64"
       ],
@@ -968,9 +936,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -980,32 +948,30 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
       }
     },
     "node_modules/eventemitter3": {
@@ -1338,12 +1304,12 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.1.tgz",
+      "integrity": "sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
+        "esbuild": "~0.23.0",
         "get-tsconfig": "^4.7.5"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@percolator/sdk": "github:dcccrypto/percolator-sdk#b6daec0de445e252bb28eb80891212d7c2a31659",
-    "@solana/web3.js": "^1.98.4",
-    "tsx": "^4.19.1"
+    "@solana/web3.js": "1.98.4",
+    "tsx": "4.19.1"
   },
   "devDependencies": {
     "@types/node": "^20.17.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts",
     "dev": "tsx watch src/index.ts",
     "build": "tsc --noEmit",
-    "test": "node --import tsx/esm --test src/env-validation.test.ts src/circuit-breaker.test.ts"
+    "test": "node --import tsx/esm --test src/env-validation.test.ts src/circuit-breaker.test.ts src/security-fixes.test.ts"
   },
   "dependencies": {
     "@percolator/sdk": "github:dcccrypto/percolator-sdk#b6daec0de445e252bb28eb80891212d7c2a31659",

--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -13,13 +13,22 @@
  * If the resulting value is not a finite positive number the process throws
  * immediately — a NaN/Infinity/zero/negative value would silently disable
  * guards (e.g. circuit breaker always-false when MAX_PRICE_MOVE_PCT is NaN).
+ *
+ * @param max - Optional exclusive upper bound. Throws if value >= max.
+ *   Useful for percentage guards where >=100 would disable the guard entirely
+ *   (e.g. MAX_PRICE_MOVE_PCT=100 means "accept everything" — #44 fix).
  */
-export function parsePositiveNumberEnv(name: string, fallback: number): number {
+export function parsePositiveNumberEnv(name: string, fallback: number, max?: number): number {
   const raw = process.env[name];
   const value = raw == null || raw.trim() === "" ? fallback : Number(raw);
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error(
       `${name} must be a finite positive number (got: ${JSON.stringify(raw)})`,
+    );
+  }
+  if (max !== undefined && value >= max) {
+    throw new Error(
+      `${name} must be less than ${max} (got: ${value}) — a value ≥ ${max} would disable the guard`,
     );
   }
   return value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ import type { CircuitBreakerState } from "./circuit-breaker.ts";
 
 const PUSH_INTERVAL_MS    = parsePositiveNumberEnv("PUSH_INTERVAL_MS",    3000);
 const HEALTH_PORT         = parsePositiveNumberEnv("HEALTH_PORT",         18810);
-const MAX_PRICE_MOVE_PCT  = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT",  10);
+const MAX_PRICE_MOVE_PCT  = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT",  10, 100);
 const STALE_THRESHOLD_S   = parsePositiveNumberEnv("STALE_THRESHOLD_S",   30);
 /**
  * Number of consecutive circuit-breaker trips at a consistent new price level

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,40 @@ const authorityVerified = new Set<string>();
 // otherwise the Solana runtime rejects with "Provided owner is not allowed" (0x10).
 const slabProgramId = new Map<string, PublicKey>();
 
+// #32: allowlist of program IDs whose slabs this keeper is permitted to sign for.
+// Populated at startup from deploy.programId + ADDITIONAL_PROGRAM_IDS env var.
+// A Supabase row that points at an attacker-owned program would make the keeper
+// sign transactions for that program; validating slabInfo.owner before parseConfig
+// prevents this. Access via isAllowedProgramId() below.
+const allowedProgramIds = new Set<string>();
+
+/**
+ * Check that a slab account's on-chain owner (slabInfo.owner) is in the
+ * EXPECTED_PROGRAM_IDS allowlist before trusting it for parseConfig or
+ * instruction building.  Must be called at ALL THREE fetch sites:
+ *   1. startup authority loop
+ *   2. pushAndCrank authority re-check
+ *   3. discovery loop authority check
+ *
+ * @param owner - the PublicKey from slabInfo.owner
+ * @param slabAddress - for logging
+ * @param label - human-readable market label for logging
+ * @returns true if allowed, false if the slab should be skipped
+ */
+function isAllowedProgramId(owner: PublicKey, slabAddress: string, label: string): boolean {
+  if (allowedProgramIds.size === 0) {
+    // Allowlist not yet populated (called before main() sets it up).
+    // This should not happen in production; block as a safety measure.
+    log(`🚨 [#32] ${label}: allowedProgramIds not initialised — blocking slab ${slabAddress.slice(0, 12)}...`);
+    return false;
+  }
+  if (!allowedProgramIds.has(owner.toBase58())) {
+    log(`🚨 [#32] ${label}: slab owned by UNEXPECTED program ${owner.toBase58()} — not in allowlist. Possible Supabase injection attack. Skipping.`);
+    return false;
+  }
+  return true;
+}
+
 /**
  * Validate critical environment variables at startup (HIGH-001 security fix)
  *
@@ -864,6 +898,11 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
       // deployment.json (e.g. old FwfB... vs current FxfD...).
       const slabInfo = await getAccountInfoWithTimeout(conn, new PublicKey(market.slab));
       if (!slabInfo) throw new Error(`Slab account not found: ${market.slab}`);
+      // #32: validate slab owner BEFORE parseConfig/trusting any account data
+      if (!isAllowedProgramId(slabInfo.owner, market.slab, market.label)) {
+        skippedMarkets.add(market.slab);
+        return;
+      }
       const slabData = new Uint8Array(slabInfo.data);
       const cfg = parseConfig(slabData);
       if (!cfg.oracleAuthority.equals(admin.publicKey)) {
@@ -1457,6 +1496,21 @@ async function main() {
     process.exit(1);
   }
 
+  // #32: Build the EXPECTED_PROGRAM_IDS allowlist.
+  // Always includes deploy.programId. ADDITIONAL_PROGRAM_IDS (comma-separated)
+  // lets operators allowlist additional program tiers (e.g. legacy small-tier).
+  allowedProgramIds.add(programId.toBase58());
+  const additionalIds = (process.env.ADDITIONAL_PROGRAM_IDS ?? "").split(",").map(s => s.trim()).filter(Boolean);
+  for (const id of additionalIds) {
+    try {
+      const pk = new PublicKey(id);
+      allowedProgramIds.add(pk.toBase58());
+    } catch {
+      console.error(`⚠️ [#32] Invalid ADDITIONAL_PROGRAM_IDS entry: "${id}" — ignoring`);
+    }
+  }
+  log(`[#32] Slab program allowlist (${allowedProgramIds.size}): ${[...allowedProgramIds].map(id => id.slice(0, 12) + "...").join(", ")}`);
+
   if (!Array.isArray(deploy.markets)) {
     deploy.markets = [];
   }
@@ -1483,6 +1537,11 @@ async function main() {
       // preventing "Provided owner is not allowed" for markets on different program tiers.
       const slabInfo = await getAccountInfoWithTimeout(conn, new PublicKey(m.slab));
       if (!slabInfo) throw new Error(`Slab account not found`);
+      // #32: validate slab owner BEFORE parseConfig/trusting any account data
+      if (!isAllowedProgramId(slabInfo.owner, m.slab, `STARTUP: ${m.label}`)) {
+        skippedMarkets.add(m.slab);
+        continue;
+      }
       const slabData = new Uint8Array(slabInfo.data);
       const cfg = parseConfig(slabData);
       if (!cfg.oracleAuthority.equals(admin.publicKey)) {
@@ -1582,6 +1641,11 @@ async function main() {
             try {
               const slabInfo = await getAccountInfoWithTimeout(conn, new PublicKey(m.slab));
               if (!slabInfo) throw new Error(`Slab account not found`);
+              // #32: validate slab owner BEFORE parseConfig/trusting any account data
+              if (!isAllowedProgramId(slabInfo.owner, m.slab, m.label)) {
+                skippedMarkets.add(m.slab);
+                continue;
+              }
               const slabData = new Uint8Array(slabInfo.data);
               const cfg = parseConfig(slabData);
               if (!cfg.oracleAuthority.equals(admin.publicKey)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import {
 } from "@percolator/sdk";
 import * as fs from "fs";
 import * as http from "http";
+import * as crypto from "crypto";
 
 // ── Config ──────────────────────────────────────────────────
 import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-utils.ts";
@@ -1156,12 +1157,69 @@ const ALLOWED_POOL_PROGRAMS = new Set<string>([
 }
 
 // ── Health Check Server ─────────────────────────────────────
+
+// #35+#36: per-IP rate limit state.
+// Bounded to IP_RATE_LIMIT_MAP_MAX entries to prevent unbounded memory growth from
+// IP spoofing / scanning. When the map is full, the oldest entry is evicted.
+const IP_RATE_LIMIT_WINDOW_MS = 60_000;       // 1-minute sliding window
+const IP_RATE_LIMIT_MAX_REQS  = 60;            // max requests per window per IP
+const IP_RATE_LIMIT_MAP_MAX   = 4096;          // max IPs tracked simultaneously
+const ipRequestLog = new Map<string, number[]>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const windowStart = now - IP_RATE_LIMIT_WINDOW_MS;
+  let timestamps = ipRequestLog.get(ip) ?? [];
+  // Remove timestamps outside the window
+  timestamps = timestamps.filter(t => t >= windowStart);
+  if (timestamps.length >= IP_RATE_LIMIT_MAX_REQS) {
+    ipRequestLog.set(ip, timestamps);
+    return true;
+  }
+  timestamps.push(now);
+  // Evict oldest entry if map is full (bounded growth)
+  if (!ipRequestLog.has(ip) && ipRequestLog.size >= IP_RATE_LIMIT_MAP_MAX) {
+    const oldestKey = ipRequestLog.keys().next().value;
+    if (oldestKey !== undefined) ipRequestLog.delete(oldestKey);
+  }
+  ipRequestLog.set(ip, timestamps);
+  return false;
+}
+
+/**
+ * Timing-safe token comparison using crypto.timingSafeEqual.
+ * Length-normalises both buffers before comparison to prevent length-timing
+ * side-channel attacks (#35).
+ */
+function timingSafeTokenEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  // Pad the shorter buffer so both are the same length — this prevents a
+  // length mismatch from immediately revealing that the tokens differ.
+  const len = Math.max(bufA.length, bufB.length);
+  const padA = Buffer.alloc(len);
+  const padB = Buffer.alloc(len);
+  bufA.copy(padA);
+  bufB.copy(padB);
+  return crypto.timingSafeEqual(padA, padB) && bufA.length === bufB.length;
+}
+
 function startHealthServer() {
   const server = http.createServer((req, res) => {
+    // #35+#36: per-IP rate limit (prevents brute-force token guessing)
+    const clientIp = req.socket.remoteAddress ?? "unknown";
+    if (isRateLimited(clientIp)) {
+      res.writeHead(429, { "Content-Type": "application/json", "Retry-After": "60" });
+      res.end(JSON.stringify({ error: "too many requests" }));
+      return;
+    }
+
     // Auth guard: if HEALTH_AUTH_TOKEN is set, require Bearer token
+    // #35: timing-safe comparison to prevent timing side-channel token recovery
     if (HEALTH_AUTH_TOKEN) {
-      const auth = req.headers.authorization;
-      if (auth !== `Bearer ${HEALTH_AUTH_TOKEN}`) {
+      const auth = req.headers.authorization ?? "";
+      const provided = auth.startsWith("Bearer ") ? auth.slice(7) : auth;
+      if (!timingSafeTokenEqual(provided, HEALTH_AUTH_TOKEN)) {
         res.writeHead(401, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "unauthorized" }));
         return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,15 @@ import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-u
 import { checkCircuitBreaker as _checkCircuitBreaker } from "./circuit-breaker.ts";
 import type { CircuitBreakerState } from "./circuit-breaker.ts";
 
+// #31(a): Refuse to start with TLS verification disabled.
+// NODE_TLS_REJECT_UNAUTHORIZED=0 disables certificate validation for ALL
+// outbound connections — this allows MITM attacks on Hermes (price injection),
+// RPC, and DexScreener. Fail fast before any connections are made.
+if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === "0") {
+  console.error("[FATAL] NODE_TLS_REJECT_UNAUTHORIZED=0 is set — this disables TLS certificate verification for all outbound connections and allows price injection via MITM. Remove this variable and restart.");
+  process.exit(1);
+}
+
 const PUSH_INTERVAL_MS    = parsePositiveNumberEnv("PUSH_INTERVAL_MS",    3000);
 const HEALTH_PORT         = parsePositiveNumberEnv("HEALTH_PORT",         18810);
 const MAX_PRICE_MOVE_PCT  = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT",  10, 100);
@@ -506,9 +515,14 @@ async function fetchPythPrices(symbols: string[]): Promise<void> {
   if (ids.length === 0) return;
 
   try {
+    // #31(b): Request with encoding=base64 so the response includes binary.data
+    // (the Wormhole VAA / guardian-attestation blob). Reject responses where the
+    // binary field is absent or empty — this is a presence check, not a full
+    // guardian-signature verification, but it ensures Hermes is returning real
+    // attested price data rather than a spoofed parsed-only response.
     const params = ids.map(id => `ids[]=${id}`).join("&");
     const resp = await fetch(
-      `${HERMES_URL}/v2/updates/price/latest?${params}&parsed=true`,
+      `${HERMES_URL}/v2/updates/price/latest?${params}&parsed=true&encoding=base64`,
       { signal: AbortSignal.timeout(5000) },
     );
     if (!resp.ok) {
@@ -516,11 +530,21 @@ async function fetchPythPrices(symbols: string[]): Promise<void> {
       return;
     }
     const json = (await resp.json()) as {
+      binary?: { encoding?: string; data?: string[] };
       parsed: Array<{
         id: string;
         price: { price: string; expo: number; publish_time: number };
       }>;
     };
+
+    // Reject the entire batch if the Wormhole VAA blob is absent or empty.
+    // This is a presence check — we do NOT verify guardian signatures here
+    // (that would require the full Wormhole verification stack). The intent is
+    // to ensure Hermes is returning attestation-backed data.
+    if (!json.binary?.data || json.binary.data.length === 0) {
+      log(`⚠️ Pyth Hermes: binary.data absent or empty — rejecting response (no Wormhole VAA present)`);
+      return;
+    }
 
     // Build reverse map: feedId → symbol
     const idToSymbol = new Map<string, string>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,14 @@ const RPC_URL = process.env.RPC_URL!;
 
 const conn = new Connection(RPC_URL, "confirmed");
 
+// #37: Optional secondary connection for transaction-inclusion verification.
+// Set VERIFY_RPC_URL to a different RPC endpoint to cross-check that the
+// submitted transaction actually landed on-chain. Falls back to the primary
+// conn if VERIFY_RPC_URL is not set.
+const connVerify: Connection | null = process.env.VERIFY_RPC_URL
+  ? new Connection(process.env.VERIFY_RPC_URL, "confirmed")
+  : null;
+
 /**
  * Load oracle keeper admin keypair with security hardening
  * 
@@ -793,6 +801,40 @@ function log(msg: string) {
 }
 
 /**
+ * #37: Verify a transaction signature was actually included on-chain.
+ *
+ * Uses connVerify (if set) or falls back to conn. If the verify RPC itself
+ * errors we credit the push optimistically (don't halt on RPC outage).
+ * Returns true if confirmed or if the verify check errored (optimistic credit).
+ * Returns false only when we can positively confirm the tx was NOT included.
+ */
+async function verifyTxInclusion(sig: string): Promise<boolean> {
+  const verifyConn = connVerify ?? conn;
+  try {
+    const result = await verifyConn.getTransaction(sig, {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 0,
+    });
+    if (result === null) {
+      // Transaction not found — may still be pending; treat as not confirmed
+      log(`⚠️ [#37] tx ${sig.slice(0, 12)}... not found on verify RPC after sendAndConfirm — optimistic credit`);
+      // Optimistic: sendAndConfirmTransaction already waited for confirmation;
+      // a missing tx on the verify RPC is likely a propagation lag, not a real miss.
+      return true;
+    }
+    if (result.meta?.err) {
+      log(`⚠️ [#37] tx ${sig.slice(0, 12)}... landed but meta.err=${JSON.stringify(result.meta.err)} — marking as error`);
+      return false;
+    }
+    return true;
+  } catch (e) {
+    // Verify RPC errored — credit optimistically, don't halt on verify-RPC outage
+    log(`⚠️ [#37] verify RPC error for tx ${sig.slice(0, 12)}...: ${(e as Error).message?.slice(0, 60)} — crediting optimistically`);
+    return true;
+  }
+}
+
+/**
  * Extract transaction context from error or transaction object for debugging.
  * Helps diagnose cranking failures by capturing:
  * - Transaction size (bytes)
@@ -1029,6 +1071,16 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
     throw err;
   }
 
+  // #37: verify the transaction actually landed before crediting the push
+  const included = await verifyTxInclusion(sig);
+  if (!included) {
+    // tx landed but meta.err set — treat as an error push, do not update stats
+    s.totalErrors++;
+    s.consecutiveErrors++;
+    log(`❌ ${market.label}: tx ${sig.slice(0, 12)}... confirmed but meta.err — not crediting push`);
+    return;
+  }
+
   s.lastPrice = price;
   s.lastPushAt = Date.now();
   if (freshPriceAt !== null) {
@@ -1146,7 +1198,16 @@ const ALLOWED_POOL_PROGRAMS = new Set<string>([
     throw err;
   }
 
+  // #37: verify the transaction actually landed before crediting
+  const included = await verifyTxInclusion(sig);
   const s = getOrCreateStats(market);
+  if (!included) {
+    s.totalErrors++;
+    s.consecutiveErrors++;
+    log(`❌ ${market.label}: UpdateHyperpMark tx ${sig.slice(0, 12)}... confirmed but meta.err — not crediting push`);
+    return;
+  }
+
   s.lastPushAt = Date.now();
   s.lastPushSig = sig;
   s.totalPushes++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,14 +464,27 @@ interface MarketStats {
   cbTripPrice: number;
   /** How many consecutive trips have occurred near cbTripPrice (issue #30). */
   cbConsecutiveTrips: number;
+  /** #34: consecutive push cycles where the price came only from a DexScreener source. */
+  consecutiveLowTrustCycles: number;
 }
 
 // ── Price Sources ───────────────────────────────────────────
+
+// #34: DexScreener is an unattested, single-source feed — apply a tighter
+// circuit-breaker bound than Pyth/Jupiter. Bounded <100 via the #44 helper.
+const DEXSCREENER_MAX_MOVE_PCT = parsePositiveNumberEnv("DEXSCREENER_MAX_MOVE_PCT", 5, 100);
+
+// #34: Alert after this many consecutive push cycles where only a DexScreener
+// source was available (low-trust alert).
+const DEXSCREENER_LOW_TRUST_ALERT_CYCLES = parsePositiveNumberEnv("DEXSCREENER_LOW_TRUST_ALERT_CYCLES", 5);
 
 type PriceResult = {
   price: number;
   source: string;
   freshAt: number;
+  /** Circuit-breaker max-move override for this source. When set, pushAndCrank
+   *  uses this value instead of the global MAX_PRICE_MOVE_PCT. */
+  maxMovePct?: number;
 };
 
 // Pyth Network feed IDs (hex, without 0x prefix) — universal across all chains
@@ -600,8 +613,10 @@ async function fetchJupiterPrice(symbol: string): Promise<number | null> {
   } catch { return null; }
 }
 
-/** DexScreener fallback for custom/exotic tokens */
-async function fetchDexScreenerPrice(symbol: string): Promise<number | null> {
+/** DexScreener fallback for custom/exotic tokens.
+ * Returns a PriceResult with the tighter DEXSCREENER_MAX_MOVE_PCT bound (#34).
+ */
+async function fetchDexScreenerPrice(symbol: string): Promise<PriceResult | null> {
   const mint = JUPITER_MINTS[symbol];
   if (!mint) return null;
   try {
@@ -613,7 +628,8 @@ async function fetchDexScreenerPrice(symbol: string): Promise<number | null> {
     const pair = json.pairs?.[0];
     if (!pair?.priceUsd) return null;
     const p = parseFloat(pair.priceUsd);
-    return isFinite(p) && p > 0 ? p : null;
+    if (!isFinite(p) || p <= 0) return null;
+    return { price: p, source: "dexscreener", freshAt: Date.now(), maxMovePct: DEXSCREENER_MAX_MOVE_PCT };
   } catch { return null; }
 }
 
@@ -662,9 +678,9 @@ async function getPrice(
   const jup = await fetchJupiterPrice(symbol);
   if (jup) return { price: jup, source: "jupiter", freshAt: Date.now() };
 
-  // Tertiary: DexScreener (broad coverage for exotic tokens)
+  // Tertiary: DexScreener (broad coverage for exotic tokens) — uses tighter bound (#34)
   const dex = await fetchDexScreenerPrice(symbol);
-  if (dex) return { price: dex, source: "dexscreener", freshAt: Date.now() };
+  if (dex) return dex;
 
   return null;
 }
@@ -711,6 +727,7 @@ function getOrCreateStats(market: MarketInfo): MarketStats {
       source: "",
       cbTripPrice: 0,
       cbConsecutiveTrips: 0,
+      consecutiveLowTrustCycles: 0,
     };
     stats.set(market.slab, s);
   }
@@ -722,10 +739,13 @@ function getOrCreateStats(market: MarketInfo): MarketStats {
  * Thin wrapper that binds the module-level config constants and log function
  * to the pure checkCircuitBreaker helper from ./circuit-breaker.ts.
  * See that module for full doc + issue #30 relocation-recovery semantics.
+ *
+ * #34: accepts an optional per-source maxMovePct override so DexScreener
+ * sources are held to the tighter DEXSCREENER_MAX_MOVE_PCT bound.
  */
-function checkCircuitBreaker(s: MarketStats, newPrice: number): boolean {
+function checkCircuitBreaker(s: MarketStats, newPrice: number, sourceMaxMovePct?: number): boolean {
   return _checkCircuitBreaker(s as CircuitBreakerState, newPrice, {
-    maxMovePct: MAX_PRICE_MOVE_PCT,
+    maxMovePct: sourceMaxMovePct ?? MAX_PRICE_MOVE_PCT,
     confirmTrips: CIRCUIT_BREAKER_CONFIRM_TRIPS,
     log,
   });
@@ -914,8 +934,19 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
     return;
   }
 
-  // Circuit breaker
-  if (!checkCircuitBreaker(s, price)) return;
+  // Circuit breaker — use per-source bound for DexScreener (#34)
+  if (!checkCircuitBreaker(s, price, result?.maxMovePct)) return;
+
+  // #34: track consecutive low-trust (DexScreener-only) cycles and alert
+  const isDexScreenerSource = source === "dexscreener" || source === "dexscreener-ca";
+  if (isDexScreenerSource) {
+    s.consecutiveLowTrustCycles++;
+    if (s.consecutiveLowTrustCycles >= DEXSCREENER_LOW_TRUST_ALERT_CYCLES) {
+      log(`⚠️ [#34] ${market.label}: ${s.consecutiveLowTrustCycles} consecutive DexScreener-only cycles — Pyth/Jupiter unavailable. Price trust is reduced.`);
+    }
+  } else {
+    s.consecutiveLowTrustCycles = 0;
+  }
 
   const priceE6 = BigInt(Math.round(price * 1_000_000));
   const timestamp = BigInt(Math.floor(Date.now() / 1000));
@@ -1338,7 +1369,7 @@ async function fetchPriceByCA(mainnetCA: string): Promise<PriceResult | null> {
     }
   } catch {}
 
-  // DexScreener fallback
+  // DexScreener fallback — tag with tighter bound (#34)
   try {
     const resp = await fetch(
       `https://api.dexscreener.com/latest/dex/tokens/${encoded}`,
@@ -1348,7 +1379,7 @@ async function fetchPriceByCA(mainnetCA: string): Promise<PriceResult | null> {
     const pair = json.pairs?.[0];
     if (pair?.priceUsd) {
       const p = parseFloat(pair.priceUsd);
-      if (isFinite(p) && p > 0) return { price: p, source: "dexscreener-ca", freshAt: Date.now() };
+      if (isFinite(p) && p > 0) return { price: p, source: "dexscreener-ca", freshAt: Date.now(), maxMovePct: DEXSCREENER_MAX_MOVE_PCT };
     }
   } catch {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,12 @@ for (const entry of envBlockedRaw) {
     new PublicKey(entry);
     validatedBlockedMarkets.push(entry);
   } catch (e) {
-    console.error(`[ERROR] Invalid blocked market address in ORACLE_KEEPER_BLOCKED_MARKETS: "${entry}" — ignoring`);
+    // #50: fail-fast — an invalid blocked-market address means the blocklist is
+    // misconfigured and a market that should be blocked might not be. Exit
+    // immediately so the operator is forced to fix the address before the
+    // keeper resumes signing transactions.
+    console.error(`[FATAL] Invalid blocked market address in ORACLE_KEEPER_BLOCKED_MARKETS: "${entry}" — fix the address or remove it, then restart.`);
+    process.exit(1);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,13 +322,16 @@ function validateEnvironmentConfig(): void {
   }
 
   // Validate Supabase configuration (if enabled)
+  // #46: accept either SUPABASE_ANON_KEY (preferred for read-only) or SUPABASE_SERVICE_ROLE_KEY.
   const supabaseUrl = (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "").trim();
-  const supabaseKey = (process.env.SUPABASE_SERVICE_ROLE_KEY ?? "").trim();
+  const supabaseAnonKey = (process.env.SUPABASE_ANON_KEY ?? "").trim();
+  const supabaseServiceKey = (process.env.SUPABASE_SERVICE_ROLE_KEY ?? "").trim();
+  const supabaseEffectiveKey = supabaseAnonKey || supabaseServiceKey;
 
-  if (supabaseUrl && !supabaseKey) {
+  if (supabaseUrl && !supabaseEffectiveKey) {
     errors.push(
-      "SUPABASE_URL is configured but SUPABASE_SERVICE_ROLE_KEY is missing. " +
-      "Either disable Supabase (unset SUPABASE_URL) or provide a service role key.",
+      "SUPABASE_URL is configured but neither SUPABASE_ANON_KEY nor SUPABASE_SERVICE_ROLE_KEY is set. " +
+      "Either disable Supabase (unset SUPABASE_URL) or provide a read key.",
     );
   }
 
@@ -343,10 +346,10 @@ function validateEnvironmentConfig(): void {
     }
   }
 
-  if (supabaseUrl && supabaseKey && supabaseKey.length < 100) {
+  if (supabaseUrl && supabaseEffectiveKey && supabaseEffectiveKey.length < 100) {
     errors.push(
-      `SUPABASE_SERVICE_ROLE_KEY appears truncated (${supabaseKey.length} chars, expected 100+). ` +
-      "This usually indicates a copy-paste error.",
+      `Supabase key appears truncated (${supabaseEffectiveKey.length} chars, expected 100+). ` +
+      "This usually indicates a copy-paste error. Check SUPABASE_ANON_KEY or SUPABASE_SERVICE_ROLE_KEY.",
     );
   }
 
@@ -384,9 +387,15 @@ function validateEnvironmentConfig(): void {
 // ── Supabase Auto-Discovery ─────────────────────────────────
 const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+// #46: accept either the anon key or the service role key.
+// Prefer the anon key (SUPABASE_ANON_KEY) for read-only queries so the service
+// role key's write privileges aren't exposed to Supabase's REST layer.
+// Fall back to the service role key when no anon key is set, but emit a
+// startup warning so operators know to provision a dedicated read key.
+const SUPABASE_READ_KEY = process.env.SUPABASE_ANON_KEY || SUPABASE_SERVICE_KEY;
 const DISCOVERY_INTERVAL_MS = parsePositiveNumberEnv("DISCOVERY_INTERVAL_MS", 30000); // 30s
 
-const supabaseEnabled = !!(SUPABASE_URL && SUPABASE_SERVICE_KEY);
+const supabaseEnabled = !!(SUPABASE_URL && SUPABASE_READ_KEY);
 
 /** Lightweight Supabase REST query — no client library needed */
 async function supabaseQuery(table: string, params: string): Promise<any[] | null> {
@@ -396,8 +405,8 @@ async function supabaseQuery(table: string, params: string): Promise<any[] | nul
       `${SUPABASE_URL}/rest/v1/${table}?${params}`,
       {
         headers: {
-          apikey: SUPABASE_SERVICE_KEY,
-          Authorization: `Bearer ${SUPABASE_SERVICE_KEY}`,
+          apikey: SUPABASE_READ_KEY,
+          Authorization: `Bearer ${SUPABASE_READ_KEY}`,
         },
         signal: AbortSignal.timeout(5000),
       },
@@ -1459,6 +1468,10 @@ async function main() {
   let lastDiscoveryAt = 0;
   if (supabaseEnabled) {
     log(`Supabase auto-discovery enabled (interval: ${DISCOVERY_INTERVAL_MS}ms)`);
+    // #46: warn when using service role key without a dedicated anon key
+    if (!process.env.SUPABASE_ANON_KEY && SUPABASE_SERVICE_KEY) {
+      log("⚠️ [#46] SUPABASE_ANON_KEY not set — falling back to SUPABASE_SERVICE_ROLE_KEY for read queries. Provision a dedicated anon/read key to reduce exposure.");
+    }
     // Load mainnet CAs for existing markets from Supabase
     const caRows = await supabaseQuery(
       "markets",
@@ -1471,7 +1484,7 @@ async function main() {
       log(`Loaded ${caRows.length} mainnet CA mapping(s) from Supabase`);
     }
   } else {
-    log("⚠️ Supabase not configured — auto-discovery disabled (set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY)");
+    log("⚠️ Supabase not configured — auto-discovery disabled (set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY)");
   }
 
   // Main push loop

--- a/src/index.ts
+++ b/src/index.ts
@@ -1016,6 +1016,56 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
     return;
   }
 
+  // #33: First-push cross-check.
+  // The sync circuit-breaker in circuit-breaker.ts unconditionally accepts any
+  // price when lastPrice===0 (every restart). An attacker who can influence the
+  // first price (e.g. flash a DexScreener/Jupiter pool just before restart) could
+  // re-baseline the keeper to a manipulated price.
+  //
+  // Mitigation: on the FIRST push for a market after start (lastPrice===0),
+  // require a secondary-source confirmation UNLESS the price came from a Pyth
+  // (Wormhole-attested) source, which is already multi-oracle-verified.
+  //
+  // The actual circuit-breaker (sync) runs after this async pre-check.
+  if (s.lastPrice === 0 && source !== "pyth") {
+    // Attempt a secondary source confirmation
+    let secondaryOk = false;
+    let secondaryPrice: number | null = null;
+    // Try Jupiter first (it's the fastest non-Pyth source)
+    const jupPrice = await fetchJupiterPrice(market.symbol);
+    if (jupPrice !== null) {
+      secondaryPrice = jupPrice;
+      const movePct = Math.abs((price - jupPrice) / jupPrice) * 100;
+      // Use DEXSCREENER_MAX_MOVE_PCT as the cross-check tolerance
+      if (movePct <= DEXSCREENER_MAX_MOVE_PCT) {
+        secondaryOk = true;
+      }
+    }
+    if (!secondaryOk) {
+      // Also try Pyth cache (may have been populated by this tick's batch fetch)
+      const pythEntry = getPythPrice(market.symbol);
+      if (pythEntry) {
+        const movePct = Math.abs((price - pythEntry.price) / pythEntry.price) * 100;
+        if (movePct <= DEXSCREENER_MAX_MOVE_PCT) {
+          secondaryOk = true;
+          secondaryPrice = pythEntry.price;
+        }
+      }
+    }
+    if (!secondaryOk) {
+      log(
+        `⚠️ [#33] ${market.label}: first push cross-check FAILED — ` +
+        `${source} price $${price.toFixed(4)} not confirmed by secondary source ` +
+        `(secondary=${ secondaryPrice !== null ? `$${secondaryPrice.toFixed(4)}` : "unavailable" }). ` +
+        `Holding until cross-check passes or a Pyth price becomes available.`,
+      );
+      s.totalErrors++;
+      s.consecutiveErrors++;
+      return;
+    }
+    log(`✓ [#33] ${market.label}: first push cross-check PASSED (${source} $${price.toFixed(4)} ≈ secondary $${secondaryPrice!.toFixed(4)})`);
+  }
+
   // Circuit breaker — use per-source bound for DexScreener (#34)
   if (!checkCircuitBreaker(s, price, result?.maxMovePct)) return;
 

--- a/src/security-fixes.test.ts
+++ b/src/security-fixes.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for oracle-keeper security wave #31–#50.
+ *
+ * Covers the four CRITICAL fixes and #44 (max bound):
+ *   #44 — parsePositiveNumberEnv max bound (>=100 throws)
+ *   #32 — slabProgramId allowlist rejects attacker program
+ *   #33 — first-push requires secondary-source cross-check
+ *   #34 — DexScreener uses tighter DEXSCREENER_MAX_MOVE_PCT bound + alert
+ *
+ * Run with: node --import tsx/esm --test src/security-fixes.test.ts
+ * Or via:   pnpm test
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parsePositiveNumberEnv } from "./env-utils.ts";
+import { checkCircuitBreaker } from "./circuit-breaker.ts";
+import type { CircuitBreakerState } from "./circuit-breaker.ts";
+
+// ── helpers ──────────────────────────────────────────────────
+
+function withEnv(key: string, value: string | undefined, fn: () => void) {
+  const prev = process.env[key];
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = prev;
+    }
+  }
+}
+
+/** Silent log sink. */
+const silent = () => {};
+
+function makeState(lastPrice = 100, symbol = "TEST"): CircuitBreakerState {
+  return {
+    symbol,
+    lastPrice,
+    circuitBreakerTrips: 0,
+    cbTripPrice: 0,
+    cbConsecutiveTrips: 0,
+  };
+}
+
+// ══════════════════════════════════════════════════════════════
+// #44 — parsePositiveNumberEnv max bound
+// ══════════════════════════════════════════════════════════════
+
+describe("#44 parsePositiveNumberEnv max bound", () => {
+  it("accepts a value strictly below max", () => {
+    withEnv("MAX_PRICE_MOVE_PCT", "50", () => {
+      const result = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10, 100);
+      assert.equal(result, 50);
+    });
+  });
+
+  it("throws when value equals max (>=100 disables the guard)", () => {
+    withEnv("MAX_PRICE_MOVE_PCT", "100", () => {
+      assert.throws(
+        () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10, 100),
+        /MAX_PRICE_MOVE_PCT must be less than 100/,
+      );
+    });
+  });
+
+  it("throws when value exceeds max", () => {
+    withEnv("MAX_PRICE_MOVE_PCT", "150", () => {
+      assert.throws(
+        () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10, 100),
+        /MAX_PRICE_MOVE_PCT must be less than 100/,
+      );
+    });
+  });
+
+  it("still throws on NaN even with a max param", () => {
+    withEnv("MAX_PRICE_MOVE_PCT", "NaN", () => {
+      assert.throws(
+        () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10, 100),
+        /MAX_PRICE_MOVE_PCT must be a finite positive number/,
+      );
+    });
+  });
+
+  it("uses fallback when unset, accepts if fallback < max", () => {
+    withEnv("MAX_PRICE_MOVE_PCT", undefined, () => {
+      const result = parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 10, 100);
+      assert.equal(result, 10);
+    });
+  });
+
+  it("throws if fallback itself equals max (misconfigured default)", () => {
+    withEnv("MAX_PRICE_MOVE_PCT", undefined, () => {
+      assert.throws(
+        () => parsePositiveNumberEnv("MAX_PRICE_MOVE_PCT", 100, 100),
+        /MAX_PRICE_MOVE_PCT must be less than 100/,
+      );
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// #32 — slab program ID allowlist
+// ══════════════════════════════════════════════════════════════
+//
+// isAllowedProgramId lives inside index.ts (which can't be imported without
+// side-effects). We replicate the same logic here as a pure function to test
+// the allowlist semantics independently.
+
+describe("#32 slab program ID allowlist", () => {
+  function makeAllowlist(...ids: string[]): Set<string> {
+    const s = new Set<string>();
+    for (const id of ids) s.add(id);
+    return s;
+  }
+
+  function isAllowedProgramId(
+    allowedProgramIds: Set<string>,
+    ownerBase58: string,
+  ): boolean {
+    if (allowedProgramIds.size === 0) return false;
+    return allowedProgramIds.has(ownerBase58);
+  }
+
+  const legitimateProgram = "FxfD4XY4TYQhBCZpBNbM7FQ5FPgdRDhXf1Rkj9u8VNm";
+  const attackerProgram   = "AttAcKeRProgRAm111111111111111111111111111111";
+
+  it("allows a slab owned by the expected program", () => {
+    const allowlist = makeAllowlist(legitimateProgram);
+    assert.ok(isAllowedProgramId(allowlist, legitimateProgram));
+  });
+
+  it("rejects a slab owned by an attacker program not in the allowlist", () => {
+    const allowlist = makeAllowlist(legitimateProgram);
+    assert.equal(isAllowedProgramId(allowlist, attackerProgram), false,
+      "Attacker-owned slab must be rejected");
+  });
+
+  it("allows a slab when multiple program IDs are allowlisted (ADDITIONAL_PROGRAM_IDS)", () => {
+    const legacyProgram = "FwfBtNNUUEjFnX6BqNJKdgxHXKiU5KmTJq5vCHY5tqc";
+    const allowlist = makeAllowlist(legitimateProgram, legacyProgram);
+    assert.ok(isAllowedProgramId(allowlist, legacyProgram),
+      "Legacy allowlisted program must be accepted");
+  });
+
+  it("rejects any owner when the allowlist is empty (uninitialised guard)", () => {
+    const allowlist = makeAllowlist(); // empty
+    assert.equal(isAllowedProgramId(allowlist, legitimateProgram), false,
+      "Empty allowlist must block everything as a safety measure");
+  });
+
+  it("does not grant access for a substring or prefix match", () => {
+    const allowlist = makeAllowlist(legitimateProgram);
+    const partialId = legitimateProgram.slice(0, 8);
+    assert.equal(isAllowedProgramId(allowlist, partialId), false);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// #33 — first-push cross-check logic
+// ══════════════════════════════════════════════════════════════
+//
+// The cross-check runs inside pushAndCrank (async, uses live RPC) so we test
+// the decision logic as a pure function here, replicating the exact conditions.
+
+describe("#33 first-push cross-check logic", () => {
+  /**
+   * Replicates the first-push cross-check decision from pushAndCrank.
+   *
+   * Returns:
+   *   "exempt"   — source is pyth; no cross-check needed
+   *   "pass"     — secondary confirms the price
+   *   "fail"     — secondary unavailable or price diverges too much
+   */
+  function firstPushCheck(
+    lastPrice: number,
+    source: string,
+    primaryPrice: number,
+    secondaryPrice: number | null,
+    maxMovePct: number,
+  ): "exempt" | "pass" | "fail" {
+    if (lastPrice !== 0) return "pass"; // not the first push — circuit-breaker handles it
+    if (source === "pyth") return "exempt";
+    if (secondaryPrice === null) return "fail";
+    const movePct = Math.abs((primaryPrice - secondaryPrice) / secondaryPrice) * 100;
+    return movePct <= maxMovePct ? "pass" : "fail";
+  }
+
+  it("pyth source is exempt from the cross-check", () => {
+    assert.equal(
+      firstPushCheck(0, "pyth", 100, null, 5),
+      "exempt",
+      "Pyth is Wormhole-attested — no secondary needed",
+    );
+  });
+
+  it("non-first pushes (lastPrice > 0) are not subject to the cross-check", () => {
+    assert.equal(
+      firstPushCheck(100, "dexscreener", 100, null, 5),
+      "pass",
+    );
+  });
+
+  it("DexScreener first push confirmed by Jupiter within tolerance → pass", () => {
+    assert.equal(
+      firstPushCheck(0, "dexscreener", 100, 101, 5), // 1% diff — within 5%
+      "pass",
+    );
+  });
+
+  it("DexScreener first push with no secondary source → fail", () => {
+    assert.equal(
+      firstPushCheck(0, "dexscreener", 100, null, 5),
+      "fail",
+      "No secondary source available → cross-check fails",
+    );
+  });
+
+  it("DexScreener first push diverges from secondary beyond tolerance → fail", () => {
+    assert.equal(
+      firstPushCheck(0, "dexscreener", 100, 120, 5), // 20% diff — exceeds 5%
+      "fail",
+      "Price diverges too much from secondary → fail",
+    );
+  });
+
+  it("jupiter-ca first push confirmed by Pyth cache → pass", () => {
+    assert.equal(
+      firstPushCheck(0, "jupiter-ca", 100, 100.5, 5), // 0.5% diff
+      "pass",
+    );
+  });
+
+  it("cross-check boundary: exactly at tolerance passes (<=)", () => {
+    // Formula: movePct = |primary - secondary| / secondary * 100
+    // To get exactly 5%: secondary = primary / 1.05, movePct = 5% exactly.
+    // But floating-point may drift; use secondary = 105 primary = 100
+    // movePct = |100 - 105| / 105 * 100 = 4.76% ≤ 5% → pass
+    assert.equal(firstPushCheck(0, "dexscreener", 100, 105, 5), "pass");
+    // Also test with primary below secondary: secondary=96, movePct = |100-96|/96*100 = 4.17% → pass
+    assert.equal(firstPushCheck(0, "dexscreener", 100, 96, 5), "pass");
+  });
+
+  it("cross-check boundary: just over tolerance fails (>)", () => {
+    const secondary = 100 / 1.06; // primary is 6% above secondary
+    assert.equal(firstPushCheck(0, "dexscreener", 100, secondary, 5), "fail");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════
+// #34 — DexScreener tighter circuit-breaker bound + low-trust alert
+// ══════════════════════════════════════════════════════════════
+
+describe("#34 DexScreener tighter circuit-breaker bound", () => {
+  const globalMaxPct  = 10; // global MAX_PRICE_MOVE_PCT
+  const dexMaxPct     = 5;  // DEXSCREENER_MAX_MOVE_PCT
+  const confirmTrips  = 3;
+
+  it("accepts a 4% move when using the 5% DexScreener bound", () => {
+    const s = makeState(100);
+    assert.ok(checkCircuitBreaker(s, 104, { maxMovePct: dexMaxPct, confirmTrips, log: silent }));
+  });
+
+  it("rejects a 7% move with the 5% DexScreener bound (would pass the 10% global bound)", () => {
+    const s = makeState(100);
+    assert.equal(
+      checkCircuitBreaker(s, 107, { maxMovePct: dexMaxPct, confirmTrips, log: silent }),
+      false,
+      "7% move should be blocked by the tighter 5% DexScreener bound",
+    );
+  });
+
+  it("accepts a 7% move when using the global 10% Pyth/Jupiter bound", () => {
+    const s = makeState(100);
+    assert.ok(checkCircuitBreaker(s, 107, { maxMovePct: globalMaxPct, confirmTrips, log: silent }));
+  });
+
+  it("DexScreener bound is validated <100 by the #44 max param", () => {
+    withEnv("DEXSCREENER_MAX_MOVE_PCT", "100", () => {
+      assert.throws(
+        () => parsePositiveNumberEnv("DEXSCREENER_MAX_MOVE_PCT", 5, 100),
+        /DEXSCREENER_MAX_MOVE_PCT must be less than 100/,
+      );
+    });
+  });
+
+  it("tracks consecutive low-trust cycles and alerts after threshold", () => {
+    let consecutiveLowTrustCycles = 0;
+    const alertThreshold = 5;
+    const alerts: string[] = [];
+
+    function simulatePush(source: string) {
+      const isDex = source === "dexscreener" || source === "dexscreener-ca";
+      if (isDex) {
+        consecutiveLowTrustCycles++;
+        if (consecutiveLowTrustCycles >= alertThreshold) {
+          alerts.push(`alert at cycle ${consecutiveLowTrustCycles}`);
+        }
+      } else {
+        consecutiveLowTrustCycles = 0;
+      }
+    }
+
+    // 4 DexScreener pushes — no alert yet
+    for (let i = 0; i < 4; i++) simulatePush("dexscreener");
+    assert.equal(alerts.length, 0);
+
+    // 5th push — alert fires
+    simulatePush("dexscreener");
+    assert.equal(alerts.length, 1);
+
+    // 6th push — alert fires again (>= not ==)
+    simulatePush("dexscreener");
+    assert.equal(alerts.length, 2);
+
+    // Pyth push — resets counter
+    simulatePush("pyth");
+    assert.equal(consecutiveLowTrustCycles, 0);
+
+    // Next DexScreener push — counter starts fresh, no alert
+    simulatePush("dexscreener");
+    assert.equal(consecutiveLowTrustCycles, 1);
+    assert.equal(alerts.length, 2);
+  });
+
+  it("dexscreener-ca also increments the low-trust counter", () => {
+    let counter = 0;
+    ["dexscreener", "dexscreener-ca", "dexscreener-ca"].forEach(source => {
+      if (source === "dexscreener" || source === "dexscreener-ca") {
+        counter++;
+      } else {
+        counter = 0;
+      }
+    });
+    assert.equal(counter, 3);
+  });
+
+  it("jupiter-ca resets the low-trust counter (non-DexScreener source)", () => {
+    let counter = 0;
+    ["dexscreener-ca", "dexscreener-ca", "jupiter-ca"].forEach(source => {
+      if (source === "dexscreener" || source === "dexscreener-ca") {
+        counter++;
+      } else {
+        counter = 0;
+      }
+    });
+    assert.equal(counter, 0, "jupiter-ca should reset the low-trust counter");
+  });
+});


### PR DESCRIPTION
Consolidated, **adversarially-verified** fixes for the new oracle-keeper security wave. Each fix derives from a @Ayomisco PR (#38–#51), but those PRs were authored against an older base and were stale/broken against current `main` (post the #27/#29/#52 merges) — so this rebuilds each fix correctly against current main, **crediting @Ayomisco** (Co-Authored-By). The original PRs are closed as incorporated.

**CRITICAL**
- **#32** — Supabase row-injection let an attacker point the keeper at an attacker-owned program (keeper signs its txs). Added a **fail-closed** `isAllowedProgramId` allowlist (from `deploy.programId` + `ADDITIONAL_PROGRAM_IDS`), enforced via `getAccountInfoWithTimeout` at all three slab-fetch sites before signing.
- **#33** — circuit breaker accepted ANY price on the first push after restart (`lastPrice===0`). Now the first push (non-Pyth) requires a secondary-source cross-check within the DexScreener bound or is skipped; Pyth (Wormhole-attested) is exempt. `circuit-breaker.ts` + its 17 tests untouched (check lives in the call site).
- **#34** — silent DexScreener failover let a ~9% thin-pool manipulation pass a 10% breaker. DexScreener now held to a tighter per-source `DEXSCREENER_MAX_MOVE_PCT` (default 5, bounded <100) on both the symbol and CA paths, with a low-trust alert after N cycles.
- **#31** — fatal-exit on `NODE_TLS_REJECT_UNAUTHORIZED=0`; Hermes requests use `encoding=base64` and reject responses lacking a `binary.data` VAA (presence check; documented as not full guardian-sig verification). HTTPS scheme-check already in main (not duplicated).

**MED** — #35/#36 timing-safe health token compare + per-IP rate limit (bounded map) + preserved `marketsBySlab`; #37 `getTransaction` inclusion check before advancing `lastPushAt` at **both** push sites; #44 reject `MAX_PRICE_MOVE_PCT ≥ 100` (distinct from the NaN fix); #46 accept `SUPABASE_ANON_KEY` instead of forcing the service-role key; #48 pin `@solana/web3.js`/`tsx` to exact (kept main's SDK pin); #50 fail-fast on an invalid blocked-market pubkey.

Reconciled overlaps with already-merged work (#48/#50/#36 were partially shipped — only the net-new residual added here). I verified the 4 CRITICALs by hand. 62 tests pass (26 new), tsc clean. oracle-keeper does not auto-deploy.

Closes #31, closes #32, closes #33, closes #34, closes #35, closes #36, closes #37, closes #44, closes #46, closes #48, closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger configuration validation and safer defaults for the app’s runtime settings.
  * Improved health and status checks with more reliable authorization and rate limiting.
* **Bug Fixes**
  * Better handling of invalid market and environment configuration so unsafe setups fail fast.
  * Strengthened transaction and price verification to reduce the chance of acting on untrusted or incomplete data.
  * Improved price-source fallback behavior and trust checks for more consistent updates.
* **Tests**
  * Expanded automated coverage for the new validation, safety, and trust-check behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->