### PR TITLE
fix: use CA-based first-push validation for dynamic markets

### DIFF
--- a/src/dynamic-first-push.ts
+++ b/src/dynamic-first-push.ts
@@ -1,0 +1,30 @@
+export type DynamicFirstPushSecondarySource = "jupiter-ca" | "dexscreener-ca";
+
+export function getDynamicFirstPushSecondarySource(
+  primarySource: string,
+): DynamicFirstPushSecondarySource | null {
+  if (primarySource === "jupiter-ca") return "dexscreener-ca";
+  if (primarySource === "dexscreener-ca") return "jupiter-ca";
+  return null;
+}
+
+export function isFirstPushSecondaryWithinTolerance(
+  primaryPrice: number,
+  secondaryPrice: number | null,
+  maxMovePct: number,
+): boolean {
+  if (
+    !Number.isFinite(primaryPrice) ||
+    primaryPrice <= 0 ||
+    secondaryPrice === null ||
+    !Number.isFinite(secondaryPrice) ||
+    secondaryPrice <= 0 ||
+    !Number.isFinite(maxMovePct) ||
+    maxMovePct < 0
+  ) {
+    return false;
+  }
+
+  const movePct = Math.abs((primaryPrice - secondaryPrice) / secondaryPrice) * 100;
+  return movePct <= maxMovePct;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,10 @@ import * as crypto from "crypto";
 
 // ── Config ──────────────────────────────────────────────────
 import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-utils.ts";
+import {
+  getDynamicFirstPushSecondarySource,
+  isFirstPushSecondaryWithinTolerance,
+} from "./dynamic-first-push.ts";
 import { checkCircuitBreaker as _checkCircuitBreaker } from "./circuit-breaker.ts";
 import type { CircuitBreakerState } from "./circuit-breaker.ts";
 
@@ -1150,42 +1154,64 @@ async function pushAndCrank(market: MarketInfo, programId: PublicKey): Promise<v
   //
   // The actual circuit-breaker (sync) runs after this async pre-check.
   if (s.lastPrice === 0 && source !== "pyth") {
-    // Attempt a secondary source confirmation
+    // Attempt a secondary source confirmation.
     let secondaryOk = false;
     let secondaryPrice: number | null = null;
-    // Try Jupiter first (it's the fastest non-Pyth source)
-    const jupPrice = await fetchJupiterPrice(market.symbol);
-    if (jupPrice !== null) {
-      secondaryPrice = jupPrice;
-      const movePct = Math.abs((price - jupPrice) / jupPrice) * 100;
-      // Use DEXSCREENER_MAX_MOVE_PCT as the cross-check tolerance
-      if (movePct <= DEXSCREENER_MAX_MOVE_PCT) {
-        secondaryOk = true;
+
+    if (market.isDynamic) {
+      // #55: Dynamic markets are identified by mainnet_ca, not display symbol.
+      // Confirm CA-priced first pushes using an independent CA-based source.
+      const ca = market.slab ? slabToMainnetCA.get(market.slab) : null;
+
+      if (ca) {
+        secondaryPrice = await fetchDynamicFirstPushSecondaryPrice(ca, source);
+        secondaryOk = isFirstPushSecondaryWithinTolerance(
+          price,
+          secondaryPrice,
+          DEXSCREENER_MAX_MOVE_PCT,
+        );
       }
-    }
-    if (!secondaryOk) {
-      // Also try Pyth cache (may have been populated by this tick's batch fetch)
-      const pythEntry = getPythPrice(market.symbol);
-      if (pythEntry) {
-        const movePct = Math.abs((price - pythEntry.price) / pythEntry.price) * 100;
-        if (movePct <= DEXSCREENER_MAX_MOVE_PCT) {
-          secondaryOk = true;
+    } else {
+      // Static markets keep the existing symbol-based confirmation path.
+      const jupPrice = await fetchJupiterPrice(market.symbol);
+
+      if (jupPrice !== null) {
+        secondaryPrice = jupPrice;
+        secondaryOk = isFirstPushSecondaryWithinTolerance(
+          price,
+          jupPrice,
+          DEXSCREENER_MAX_MOVE_PCT,
+        );
+      }
+
+      if (!secondaryOk) {
+        const pythEntry = getPythPrice(market.symbol);
+
+        if (pythEntry) {
           secondaryPrice = pythEntry.price;
+          secondaryOk = isFirstPushSecondaryWithinTolerance(
+            price,
+            pythEntry.price,
+            DEXSCREENER_MAX_MOVE_PCT,
+          );
         }
       }
     }
+
     if (!secondaryOk) {
       log(
-        `⚠️ [#33] ${market.label}: first push cross-check FAILED — ` +
-        `${source} price $${price.toFixed(4)} not confirmed by secondary source ` +
-        `(secondary=${ secondaryPrice !== null ? `$${secondaryPrice.toFixed(4)}` : "unavailable" }). ` +
-        `Holding until cross-check passes or a Pyth price becomes available.`,
+        `⚠️ [#33/#55] ${market.label}: first push cross-check FAILED → ` +
+          `source=${source} price=$${price.toFixed(4)} not confirmed by ` +
+          `${market.isDynamic ? "CA-based" : "symbol-based"} secondary source ` +
+          `(secondary=${secondaryPrice !== null ? `$${secondaryPrice.toFixed(4)}` : "unavailable"}). ` +
+          `Holding until cross-check passes or a Pyth price becomes available.`,
       );
       s.totalErrors++;
       s.consecutiveErrors++;
       return;
     }
-    log(`✓ [#33] ${market.label}: first push cross-check PASSED (${source} $${price.toFixed(4)} ≈ secondary $${secondaryPrice!.toFixed(4)})`);
+
+    log(`✅ [#33/#55] ${market.label}: first push cross-check PASSED (${source} $${price.toFixed(4)} ≈ secondary $${secondaryPrice!.toFixed(4)})`);
   }
 
   // Circuit breaker — use per-source bound for DexScreener (#34)
@@ -1657,9 +1683,9 @@ async function discoverNewMarkets(): Promise<MarketInfo[]> {
  * since they may not be in PYTH_FEED_IDS or JUPITER_MINTS.
  * This fetches price directly using the mainnet CA via Jupiter Lite API.
  */
-async function fetchPriceByCA(mainnetCA: string): Promise<PriceResult | null> {
-  // Validate as base58 Solana address before using in external URLs (#783, #784)
+async function fetchJupiterPriceByCA(mainnetCA: string): Promise<number | null> {
   if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(mainnetCA)) return null;
+
   const encoded = encodeURIComponent(mainnetCA);
 
   try {
@@ -1671,11 +1697,18 @@ async function fetchPriceByCA(mainnetCA: string): Promise<PriceResult | null> {
     const data = json.data?.[mainnetCA];
     if (data?.price) {
       const p = parseFloat(data.price);
-      if (isFinite(p) && p > 0) return { price: p, source: "jupiter-ca", freshAt: Date.now() };
+      if (Number.isFinite(p) && p > 0) return p;
     }
   } catch {}
 
-  // DexScreener fallback — tag with tighter bound (#34)
+  return null;
+}
+
+async function fetchDexScreenerPriceByCA(mainnetCA: string): Promise<PriceResult | null> {
+  if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(mainnetCA)) return null;
+
+  const encoded = encodeURIComponent(mainnetCA);
+
   try {
     const resp = await fetch(
       `https://api.dexscreener.com/latest/dex/tokens/${encoded}`,
@@ -1683,11 +1716,47 @@ async function fetchPriceByCA(mainnetCA: string): Promise<PriceResult | null> {
     );
     const json = (await resp.json()) as any;
     const pair = json.pairs?.[0];
+
     if (pair?.priceUsd) {
       const p = parseFloat(pair.priceUsd);
-      if (isFinite(p) && p > 0) return { price: p, source: "dexscreener-ca", freshAt: Date.now(), maxMovePct: DEXSCREENER_MAX_MOVE_PCT };
+      if (Number.isFinite(p) && p > 0) {
+        return {
+          price: p,
+          source: "dexscreener-ca",
+          freshAt: Date.now(),
+          maxMovePct: DEXSCREENER_MAX_MOVE_PCT,
+        };
+      }
     }
   } catch {}
+
+  return null;
+}
+
+async function fetchPriceByCA(mainnetCA: string): Promise<PriceResult | null> {
+  const jupiterPrice = await fetchJupiterPriceByCA(mainnetCA);
+
+  if (jupiterPrice !== null) {
+    return { price: jupiterPrice, source: "jupiter-ca", freshAt: Date.now() };
+  }
+
+  return fetchDexScreenerPriceByCA(mainnetCA);
+}
+
+async function fetchDynamicFirstPushSecondaryPrice(
+  mainnetCA: string,
+  primarySource: string,
+): Promise<number | null> {
+  const secondarySource = getDynamicFirstPushSecondarySource(primarySource);
+
+  if (secondarySource === "dexscreener-ca") {
+    const dex = await fetchDexScreenerPriceByCA(mainnetCA);
+    return dex?.price ?? null;
+  }
+
+  if (secondarySource === "jupiter-ca") {
+    return fetchJupiterPriceByCA(mainnetCA);
+  }
 
   return null;
 }

--- a/src/security-fixes.test.ts
+++ b/src/security-fixes.test.ts
@@ -14,6 +14,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { parsePositiveNumberEnv } from "./env-utils.ts";
+import {
+  getDynamicFirstPushSecondarySource,
+  isFirstPushSecondaryWithinTolerance,
+} from "./dynamic-first-push.ts";
 import { checkCircuitBreaker } from "./circuit-breaker.ts";
 import type { CircuitBreakerState } from "./circuit-breaker.ts";
 
@@ -352,5 +356,77 @@ describe("#34 DexScreener tighter circuit-breaker bound", () => {
       }
     });
     assert.equal(counter, 0, "jupiter-ca should reset the low-trust counter");
+  });
+});
+
+
+// ══════════════════════════════════════════════════════════════
+// #55 — Dynamic CA first-push cross-check routing
+// ══════════════════════════════════════════════════════════════
+describe("#55 dynamic CA first-push cross-check", () => {
+  it("routes a jupiter-ca first push to a dexscreener-ca secondary", () => {
+    assert.equal(getDynamicFirstPushSecondarySource("jupiter-ca"), "dexscreener-ca");
+  });
+
+  it("routes a dexscreener-ca first push to a jupiter-ca secondary", () => {
+    assert.equal(getDynamicFirstPushSecondarySource("dexscreener-ca"), "jupiter-ca");
+  });
+
+  it("does not use symbol-based sources as dynamic CA secondary confirmation", () => {
+    assert.equal(getDynamicFirstPushSecondarySource("jupiter"), null);
+    assert.equal(getDynamicFirstPushSecondarySource("dexscreener"), null);
+    assert.equal(getDynamicFirstPushSecondarySource("pyth"), null);
+    assert.equal(getDynamicFirstPushSecondarySource("unknown"), null);
+  });
+
+  it("accepts a CA first push when the independent CA secondary is within tolerance", () => {
+    assert.equal(isFirstPushSecondaryWithinTolerance(100, 100.5, 5), true);
+  });
+
+  it("accepts a CA first push exactly at the tolerance boundary", () => {
+    assert.equal(isFirstPushSecondaryWithinTolerance(100, 105, 5), true);
+  });
+
+  it("rejects a CA first push when no independent CA secondary is available", () => {
+    assert.equal(isFirstPushSecondaryWithinTolerance(100, null, 5), false);
+  });
+
+  it("rejects a CA first push when the independent CA secondary diverges beyond tolerance", () => {
+    assert.equal(isFirstPushSecondaryWithinTolerance(100, 120, 5), false);
+  });
+
+  it("rejects invalid first-push comparison inputs", () => {
+    assert.equal(isFirstPushSecondaryWithinTolerance(0, 100, 5), false);
+    assert.equal(isFirstPushSecondaryWithinTolerance(100, 0, 5), false);
+    assert.equal(isFirstPushSecondaryWithinTolerance(Number.NaN, 100, 5), false);
+    assert.equal(isFirstPushSecondaryWithinTolerance(100, Number.NaN, 5), false);
+    assert.equal(isFirstPushSecondaryWithinTolerance(100, 100, -1), false);
+  });
+
+  it("mirrors issue #55: unknown dynamic symbol can bootstrap using CA-based confirmation", () => {
+    const displaySymbol = "NEWTOKEN";
+    const primarySource = "jupiter-ca";
+    const primaryPrice = 1.23;
+
+    const staticSymbolJupiter = new Map<string, number>();
+    const staticSymbolPyth = new Map<string, number>();
+    const caSecondaryPrices = new Map<string, number>([
+      ["dexscreener-ca", 1.231],
+    ]);
+
+    const symbolBasedSecondary =
+      staticSymbolJupiter.get(displaySymbol) ?? staticSymbolPyth.get(displaySymbol) ?? null;
+
+    assert.equal(symbolBasedSecondary, null, "display symbol is intentionally unknown");
+
+    const secondarySource = getDynamicFirstPushSecondarySource(primarySource);
+    const caSecondary = secondarySource ? caSecondaryPrices.get(secondarySource) ?? null : null;
+
+    assert.equal(secondarySource, "dexscreener-ca");
+    assert.equal(
+      isFirstPushSecondaryWithinTolerance(primaryPrice, caSecondary, 5),
+      true,
+      "dynamic markets should confirm first push through CA-based secondary pricing, not symbol maps",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Closes #55.

This PR fixes the dynamic market first-push cross-check path by validating dynamically discovered markets using their `mainnet_ca` identity instead of their display `symbol`.

Before this change, dynamic markets correctly fetched their primary price through the CA-based path, but the first-push cross-check still attempted to confirm the price using symbol-based Jupiter/Pyth lookups. For dynamically discovered markets, the symbol may not exist in `JUPITER_MINTS` or `PYTH_FEED_IDS`, even when the market has a valid `mainnet_ca`. This could cause a valid dynamic market to fail bootstrap when `lastPrice === 0`, because the secondary confirmation was looking up the wrong identity.

This PR keeps the first-push protection in place, but changes the dynamic market confirmation path to use CA-based secondary pricing.

---

## Background

The keeper has a first-push cross-check guard that protects markets when `lastPrice === 0`.

This guard is important because, on the first accepted price after startup, there is no prior baseline price. Without a secondary confirmation, an attacker could potentially influence the first accepted price and cause the keeper to initialize from a manipulated value.

For static markets, symbol-based confirmation is appropriate because those markets are known ahead of time and can be resolved through existing symbol mappings.

For dynamic markets, however, the correct identity is not the display symbol. Dynamically discovered markets are resolved through the slab mapping and their `mainnet_ca`. The primary dynamic price path already uses this CA identity, but the first-push confirmation path did not.

This created a mismatch:

- primary dynamic price lookup used `mainnet_ca`
- first-push confirmation used `market.symbol`

As a result, a dynamic market could have a valid CA-based primary price but still fail the first-push cross-check because its display symbol was not present in static Jupiter/Pyth symbol mappings.

---

## Root Cause

The root cause was an identity mismatch in the first-push confirmation flow.

The dynamic price path already resolves prices through:

- `market.slab`
- `slabToMainnetCA`
- `fetchPriceByCA(mainnet_ca)`

That path can return CA-based sources such as:

- `jupiter-ca`
- `dexscreener-ca`

However, when the keeper reached the first-push cross-check, it still attempted to confirm non-Pyth first pushes using:

- `fetchJupiterPrice(market.symbol)`
- `getPythPrice(market.symbol)`

This is correct for static markets, but incorrect for dynamic markets.

For dynamic markets, `market.symbol` is only a display identifier and may not be a reliable oracle lookup key. The first-push cross-check therefore needs to use the same identity as the dynamic price path: `mainnet_ca`.

---

## Changes

### 1. Added dynamic first-push helper module

This PR adds `src/dynamic-first-push.ts`.

The helper module contains small pure functions for dynamic first-push validation:

- selecting the correct independent secondary source for a CA-based primary source
- validating whether the primary price and secondary price are within tolerance

The helper intentionally only maps CA-based sources:

- `jupiter-ca` first push is confirmed by `dexscreener-ca`
- `dexscreener-ca` first push is confirmed by `jupiter-ca`

It does not map symbol-based sources such as:

- `jupiter`
- `dexscreener`
- `pyth`

This prevents dynamic markets from silently falling back to symbol-based validation.

---

### 2. Split CA price fetching into source-specific helpers

The previous CA price path was aggregated through `fetchPriceByCA(mainnet_ca)`.

This PR keeps `fetchPriceByCA(...)` as the main dynamic pricing entry point, but splits the internal CA fetching into source-specific helpers:

- `fetchJupiterPriceByCA(mainnetCA)`
- `fetchDexScreenerPriceByCA(mainnetCA)`

This allows the first-push cross-check to ask for an independent secondary source instead of accidentally reusing the same aggregated source again.

The aggregate behavior is preserved:

1. try Jupiter CA pricing first
2. fall back to DexScreener CA pricing
3. return `null` if neither source is available

This keeps the existing dynamic price behavior while making cross-check routing explicit and testable.

---

### 3. Updated first-push cross-check for dynamic markets

The first-push cross-check now branches based on market type.

For dynamic markets:

- the keeper resolves the market CA from `slabToMainnetCA`
- it fetches a CA-based secondary price
- it validates the secondary price against the primary price using the same tolerance logic
- it does not use `market.symbol` as a fallback

For static markets:

- the existing symbol-based behavior is preserved
- Jupiter symbol lookup remains the first secondary attempt
- Pyth cache symbol lookup remains the fallback secondary attempt

This keeps the security protection from the existing first-push guard while fixing the dynamic market identity mismatch.

---

### 4. Preserved the first-push security guard

This PR does not remove or bypass the first-push protection.

The guard still blocks first pushes when no valid independent secondary confirmation is available.

The important change is that the secondary confirmation now uses the correct identity for the market type:

- dynamic market → CA-based confirmation
- static market → symbol-based confirmation

This preserves the hardening intent of the original first-push guard while allowing valid dynamic markets to bootstrap correctly.

---

### 5. Added regression tests for issue #55

This PR adds regression coverage for dynamic CA first-push routing.

The tests cover:

- `jupiter-ca` first push routes to `dexscreener-ca`
- `dexscreener-ca` first push routes to `jupiter-ca`
- symbol-based sources are not accepted as dynamic CA secondary sources
- CA first push passes when the independent CA secondary is within tolerance
- CA first push passes exactly at the tolerance boundary
- CA first push fails when no independent CA secondary is available
- CA first push fails when the secondary price diverges beyond tolerance
- invalid comparison inputs are rejected
- an unknown dynamic display symbol can still bootstrap when CA-based confirmation is valid

The final test mirrors the issue #55 failure mode directly: the display symbol is intentionally unknown to static symbol maps, but the dynamic market can still pass confirmation through its CA-based secondary source.

---

## Security Impact

This PR strengthens dynamic market bootstrap behavior without weakening the first-push protection.

Before this fix, dynamic markets could fail to initialize even with valid CA pricing because the confirmation path looked up the wrong identifier. After this fix, dynamic markets must still pass an independent secondary confirmation, but that confirmation is now based on `mainnet_ca`.

This avoids two unsafe outcomes:

1. removing the first-push guard entirely for dynamic markets
2. confirming dynamic markets through unrelated or unavailable symbol-based lookups

The new behavior is stricter and more correct:

- dynamic primary source `jupiter-ca` must be confirmed by `dexscreener-ca`
- dynamic primary source `dexscreener-ca` must be confirmed by `jupiter-ca`
- dynamic markets do not fall back to `market.symbol`
- static markets keep their existing Jupiter/Pyth symbol confirmation path

This keeps the first accepted dynamic price anchored to the same asset identity used by the primary CA price lookup.

---

## Files Changed

### `src/index.ts`

Updates the dynamic first-push cross-check flow.

Key changes:

- imports dynamic first-push helper functions
- splits CA price fetching into Jupiter CA and DexScreener CA helper paths
- keeps `fetchPriceByCA(...)` as the aggregate dynamic price entry point
- adds `fetchDynamicFirstPushSecondaryPrice(...)`
- changes first-push confirmation so dynamic markets use CA-based secondary validation
- preserves the existing symbol-based confirmation path for static markets

### `src/dynamic-first-push.ts`

Adds pure helper logic for:

- selecting the independent dynamic secondary source
- validating primary/secondary first-push price tolerance
- rejecting invalid comparison inputs

### `src/security-fixes.test.ts`

Adds issue #55 regression tests for:

- CA-based secondary source routing
- tolerance boundary behavior
- unavailable secondary source behavior
- invalid input rejection
- unknown dynamic symbol bootstrap through CA-based confirmation

---

## Tests

Validated locally with:

- `npm run build`
- `npm test`
- `git diff --check`

Final local test result:

- `tests 100`
- `pass 100`
- `fail 0`
- `cancelled 0`
- `skipped 0`

Branch verification:

- branch is based on `upstream/main`
- branch contains one commit on top of `upstream/main`
- working tree was clean before push

---

## Review Notes

The key design decision is that dynamic market first-push validation now uses `mainnet_ca`, not `market.symbol`.

This is intentional because dynamic markets are discovered and priced by CA identity. Their display symbol is not guaranteed to be present in static Jupiter/Pyth mappings and should not be used as the confirmation identity.

The PR avoids broad refactors and does not change the static market flow. It only separates dynamic CA confirmation from static symbol confirmation, which directly addresses issue #55.