### PR TITLE
fix: require secure RPC URLs by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 # Required
 RPC_URL=https://api.devnet.solana.com
+# Optional secondary HTTPS RPC endpoint for transaction-inclusion verification
+VERIFY_RPC_URL=
+# Local development only: allow http://localhost RPC endpoints. Never enable for production or remote RPC endpoints.
+ALLOW_INSECURE_LOCAL_RPC=false
 
 # Keypair — one of these required:
 # ADMIN_KEYPAIR=[1,2,3,...] (JSON array of 64 bytes — for Railway/Docker deployments)

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import * as crypto from "crypto";
 
 // ── Config ──────────────────────────────────────────────────
 import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-utils.ts";
+import { isExplicitTrue, validateRpcEndpoint } from "./rpc-url.ts";
 import { checkCircuitBreaker as _checkCircuitBreaker } from "./circuit-breaker.ts";
 import type { CircuitBreakerState } from "./circuit-breaker.ts";
 
@@ -144,7 +145,7 @@ const ADMIN_KP_PATH = process.env.ADMIN_KEYPAIR_PATH ??
 // RPC_URL is required and validated at startup by validateEnvironmentConfig()
 // Removed silent fallback to prevent misconfigured production deployments from
 // accidentally connecting to public devnet (HIGH-002 security hardening)
-const RPC_URL = process.env.RPC_URL!;
+const RPC_URL = process.env.RPC_URL!.trim();
 
 const conn = new Connection(RPC_URL, "confirmed");
 
@@ -152,8 +153,9 @@ const conn = new Connection(RPC_URL, "confirmed");
 // Set VERIFY_RPC_URL to a different RPC endpoint to cross-check that the
 // submitted transaction actually landed on-chain. Falls back to the primary
 // conn if VERIFY_RPC_URL is not set.
-const connVerify: Connection | null = process.env.VERIFY_RPC_URL
-  ? new Connection(process.env.VERIFY_RPC_URL, "confirmed")
+const VERIFY_RPC_URL = (process.env.VERIFY_RPC_URL ?? "").trim();
+const connVerify: Connection | null = VERIFY_RPC_URL
+  ? new Connection(VERIFY_RPC_URL, "confirmed")
   : null;
 
 /**
@@ -448,20 +450,24 @@ async function getAccountInfoWithTimeout(
 function validateEnvironmentConfig(): void {
   const errors: string[] = [];
 
-  // Validate RPC_URL (critical — cannot crank without valid RPC)
+  // Validate RPC endpoints.
+  // #69: RPC transport is oracle-critical. Production endpoints must use HTTPS.
+  // Plaintext HTTP is only allowed for explicit local development opt-in.
+  const allowInsecureLocalRpc = isExplicitTrue(process.env.ALLOW_INSECURE_LOCAL_RPC);
+
   const rpcUrl = (process.env.RPC_URL ?? "").trim();
-  if (!rpcUrl) {
-    errors.push("RPC_URL is required but not set or empty. Set RPC_URL to your Solana RPC endpoint.");
-  } else {
-    try {
-      const url = new URL(rpcUrl);
-      if (!url.protocol.match(/^https?:$/)) {
-        errors.push(`RPC_URL must use http or https protocol, got: ${url.protocol}`);
-      }
-    } catch (e) {
-      errors.push(`RPC_URL is not a valid URL: ${rpcUrl}`);
-    }
-  }
+  const rpcUrlError = validateRpcEndpoint("RPC_URL", rpcUrl, {
+    required: true,
+    allowInsecureLocalRpc,
+  });
+  if (rpcUrlError) errors.push(rpcUrlError);
+
+  const verifyRpcUrl = (process.env.VERIFY_RPC_URL ?? "").trim();
+  const verifyRpcUrlError = validateRpcEndpoint("VERIFY_RPC_URL", verifyRpcUrl, {
+    required: false,
+    allowInsecureLocalRpc,
+  });
+  if (verifyRpcUrlError) errors.push(verifyRpcUrlError);
 
   // Validate HERMES_URL (must be HTTPS to prevent SSRF and price injection)
   const hermesUrl = (process.env.HERMES_URL ?? "").trim();

--- a/src/rpc-url.ts
+++ b/src/rpc-url.ts
@@ -1,0 +1,62 @@
+export type RpcEndpointValidationOptions = {
+  required?: boolean;
+  allowInsecureLocalRpc?: boolean;
+};
+
+export function isExplicitTrue(value: string | undefined): boolean {
+  return (value ?? "").trim().toLowerCase() === "true";
+}
+
+export function isLocalRpcHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+}
+
+export function validateRpcEndpoint(
+  name: string,
+  rawUrl: string | undefined,
+  options: RpcEndpointValidationOptions = {},
+): string | null {
+  const required = options.required ?? false;
+  const allowInsecureLocalRpc = options.allowInsecureLocalRpc ?? false;
+  const value = (rawUrl ?? "").trim();
+
+  if (!value) {
+    if (required) {
+      return `${name} is required but not set or empty. Set ${name} to your Solana RPC endpoint.`;
+    }
+
+    return null;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(value);
+  } catch {
+    return `${name} is not a valid URL: ${value}`;
+  }
+
+  if (url.protocol === "https:") {
+    return null;
+  }
+
+  if (url.protocol === "http:") {
+    if (allowInsecureLocalRpc && isLocalRpcHostname(url.hostname)) {
+      return null;
+    }
+
+    return (
+      `${name} must use secure https protocol. ` +
+      "Plaintext http is only allowed for localhost when ALLOW_INSECURE_LOCAL_RPC=true."
+    );
+  }
+
+  return `${name} must use secure https protocol, got: ${url.protocol}`;
+}

--- a/src/security-fixes.test.ts
+++ b/src/security-fixes.test.ts
@@ -14,6 +14,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { parsePositiveNumberEnv } from "./env-utils.ts";
+import { isExplicitTrue, validateRpcEndpoint } from "./rpc-url.ts";
 import { checkCircuitBreaker } from "./circuit-breaker.ts";
 import type { CircuitBreakerState } from "./circuit-breaker.ts";
 
@@ -352,5 +353,102 @@ describe("#34 DexScreener tighter circuit-breaker bound", () => {
       }
     });
     assert.equal(counter, 0, "jupiter-ca should reset the low-trust counter");
+  });
+});
+
+
+// ══════════════════════════════════════════════════════════════
+// #69 — Secure RPC URL validation
+// ══════════════════════════════════════════════════════════════
+describe("#69 secure RPC URL validation", () => {
+  it("accepts HTTPS RPC_URL", () => {
+    assert.equal(
+      validateRpcEndpoint("RPC_URL", "https://rpc.example.com", { required: true }),
+      null,
+    );
+  });
+
+  it("rejects missing required RPC_URL", () => {
+    assert.match(
+      validateRpcEndpoint("RPC_URL", "", { required: true }) ?? "",
+      /RPC_URL is required/,
+    );
+  });
+
+  it("allows empty optional VERIFY_RPC_URL", () => {
+    assert.equal(
+      validateRpcEndpoint("VERIFY_RPC_URL", "", { required: false }),
+      null,
+    );
+  });
+
+  it("rejects plaintext remote RPC_URL by default", () => {
+    assert.match(
+      validateRpcEndpoint("RPC_URL", "http://attacker-rpc.local", { required: true }) ?? "",
+      /must use secure https protocol/,
+    );
+  });
+
+  it("rejects plaintext remote VERIFY_RPC_URL by default", () => {
+    assert.match(
+      validateRpcEndpoint("VERIFY_RPC_URL", "http://attacker-verify-rpc.local") ?? "",
+      /must use secure https protocol/,
+    );
+  });
+
+  it("rejects plaintext localhost RPC_URL unless explicitly allowed", () => {
+    assert.match(
+      validateRpcEndpoint("RPC_URL", "http://localhost:8899", { required: true }) ?? "",
+      /must use secure https protocol/,
+    );
+  });
+
+  it("allows plaintext localhost RPC_URL only with explicit local-development opt-in", () => {
+    assert.equal(
+      validateRpcEndpoint("RPC_URL", "http://localhost:8899", {
+        required: true,
+        allowInsecureLocalRpc: true,
+      }),
+      null,
+    );
+
+    assert.equal(
+      validateRpcEndpoint("VERIFY_RPC_URL", "http://127.0.0.1:8899", {
+        allowInsecureLocalRpc: true,
+      }),
+      null,
+    );
+  });
+
+  it("rejects plaintext remote RPC_URL even when local insecure opt-in is enabled", () => {
+    assert.match(
+      validateRpcEndpoint("RPC_URL", "http://attacker-rpc.local", {
+        required: true,
+        allowInsecureLocalRpc: true,
+      }) ?? "",
+      /must use secure https protocol/,
+    );
+  });
+
+  it("rejects non-HTTP RPC_URL protocols", () => {
+    assert.match(
+      validateRpcEndpoint("RPC_URL", "ws://rpc.example.com", { required: true }) ?? "",
+      /must use secure https protocol/,
+    );
+  });
+
+  it("rejects invalid RPC_URL syntax", () => {
+    assert.match(
+      validateRpcEndpoint("RPC_URL", "not a url", { required: true }) ?? "",
+      /not a valid URL/,
+    );
+  });
+
+  it("parses ALLOW_INSECURE_LOCAL_RPC as explicit true only", () => {
+    assert.equal(isExplicitTrue("true"), true);
+    assert.equal(isExplicitTrue(" TRUE "), true);
+    assert.equal(isExplicitTrue("false"), false);
+    assert.equal(isExplicitTrue("1"), false);
+    assert.equal(isExplicitTrue(undefined), false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #69.

This PR hardens RPC endpoint configuration by requiring secure HTTPS transport for oracle-critical RPC connections by default.

Previously, `RPC_URL` allowed both `http://` and `https://` endpoints, and `VERIFY_RPC_URL` could be passed directly into a secondary Solana `Connection` without the same startup validation. Because both RPC endpoints are used in sensitive keeper flows, including account reads, transaction submission, confirmation, and transaction-inclusion verification, allowing plaintext HTTP could expose the keeper to network-level manipulation or attacker-controlled RPC responses.

This PR ensures that production RPC endpoints must use HTTPS, while still preserving an explicit and tightly scoped local-development escape hatch for `http://localhost` style RPC endpoints.

---

## Background

The oracle keeper relies on RPC endpoints for several critical operations:

* reading Solana account state,
* fetching blockhashes,
* submitting transactions,
* confirming submitted transactions,
* verifying transaction inclusion,
* checking transaction metadata and execution result.

Because these operations influence whether the keeper believes a price push succeeded, the transport layer must not be downgradeable to plaintext HTTP in production.

The issue was that `RPC_URL` validation accepted both `http:` and `https:` protocols. In addition, `VERIFY_RPC_URL` was optional but could be passed directly into a verification `Connection` without equivalent validation.

This meant that a deployment could accidentally or maliciously be configured with plaintext RPC endpoints.

---

## Root Cause

The root cause was incomplete RPC endpoint validation.

Before this PR:

* `RPC_URL` was required, but its protocol validation allowed `http://`.
* `VERIFY_RPC_URL` was optional, but if provided, it was used directly to construct a secondary RPC connection.
* There was no shared validation policy enforcing HTTPS for both RPC endpoints.
* There was no explicit local-development-only opt-in for insecure local RPC usage.

This created inconsistent behavior between the primary RPC connection and the optional verification RPC connection.

For an oracle keeper, this is security-sensitive because an untrusted or plaintext RPC transport can influence what the keeper sees when checking transaction state, account state, and confirmation results.

---

## Changes

### 1. Added `src/rpc-url.ts`

This PR adds a dedicated helper module for RPC endpoint validation.

The new helper includes:

* `validateRpcEndpoint(...)`
* `isExplicitTrue(...)`
* `isLocalRpcHostname(...)`

The validation helper is pure and testable. It centralizes RPC URL policy so both `RPC_URL` and `VERIFY_RPC_URL` are checked consistently.

The helper accepts:

* `https://...` endpoints by default,
* empty optional endpoints when `required: false`,
* `http://localhost` or loopback endpoints only when explicitly allowed.

The helper rejects:

* missing required `RPC_URL`,
* invalid URL syntax,
* non-HTTP protocols such as `ws://`,
* plaintext remote `http://` RPC endpoints,
* plaintext localhost endpoints unless explicitly enabled,
* plaintext remote endpoints even when local insecure mode is enabled.

---

### 2. Enforced HTTPS for `RPC_URL`

`RPC_URL` is still required, but it now must pass secure endpoint validation before the keeper continues startup.

Accepted by default:

* `https://rpc.example.com`

Rejected by default:

* `http://attacker-rpc.local`
* `http://localhost:8899`
* `ws://rpc.example.com`
* invalid URL strings
* empty `RPC_URL`

This prevents production deployments from accidentally running with plaintext RPC transport.

---

### 3. Added validation for `VERIFY_RPC_URL`

`VERIFY_RPC_URL` remains optional.

If it is not set, the keeper continues to use the primary RPC connection as before.

If it is set, it must now pass the same secure transport policy as `RPC_URL`.

Accepted:

* empty `VERIFY_RPC_URL`
* `https://verify-rpc.example.com`

Rejected by default:

* `http://attacker-verify-rpc.local`
* invalid URL syntax
* unsupported protocols

This closes the validation gap where the verification RPC endpoint could previously be created from an unvalidated environment value.

---

### 4. Added explicit local-development opt-in

This PR adds a new environment variable:

* `ALLOW_INSECURE_LOCAL_RPC=false`

By default, plaintext HTTP RPC endpoints are rejected.

For local development only, developers can explicitly enable insecure loopback RPC endpoints:

* `ALLOW_INSECURE_LOCAL_RPC=true`
* `RPC_URL=http://localhost:8899`
* `VERIFY_RPC_URL=http://127.0.0.1:8899`

The opt-in is intentionally narrow.

Even when `ALLOW_INSECURE_LOCAL_RPC=true`, remote plaintext HTTP endpoints are still rejected.

This preserves local validator workflows without weakening production safety.

---

### 5. Trimmed RPC environment values before use

`RPC_URL` is now trimmed before creating the primary Solana `Connection`.

`VERIFY_RPC_URL` is also trimmed before deciding whether to create the optional verification connection.

This avoids accidental whitespace causing inconsistent validation or connection behavior.

---

### 6. Updated `.env.example`

The example environment file now documents:

* `VERIFY_RPC_URL`
* `ALLOW_INSECURE_LOCAL_RPC=false`

The comments make clear that insecure local RPC is only for local development and should not be enabled for production or remote RPC endpoints.

---

## Security Impact

This PR strengthens keeper startup safety by making insecure RPC transport fail closed by default.

Before this fix, a plaintext RPC endpoint could be accepted and used in oracle-critical paths. After this fix, both primary and verification RPC endpoints must use HTTPS unless the endpoint is explicitly local and insecure local mode is intentionally enabled.

This reduces risk from:

* plaintext RPC traffic,
* accidental production misconfiguration,
* attacker-controlled HTTP RPC endpoints,
* MITM-style response manipulation,
* inconsistent validation between primary and verification RPC connections.

The change is intentionally focused on configuration hardening. It does not alter transaction construction, price calculation, oracle source priority, market discovery, or circuit breaker logic.

---

## Files Changed

### `.env.example`

Adds documentation for:

* `VERIFY_RPC_URL`
* `ALLOW_INSECURE_LOCAL_RPC=false`

This makes the secure default and local-development exception visible to operators.

### `src/index.ts`

Updates startup configuration handling to:

* import the new RPC URL validation helpers,
* trim `RPC_URL`,
* trim `VERIFY_RPC_URL`,
* validate `RPC_URL` as required,
* validate `VERIFY_RPC_URL` as optional,
* enforce HTTPS by default,
* allow plaintext local RPC only through explicit opt-in.

### `src/rpc-url.ts`

Adds a focused RPC validation helper module.

This module contains reusable logic for:

* strict boolean parsing,
* localhost / loopback hostname detection,
* secure RPC endpoint validation.

### `src/security-fixes.test.ts`

Adds regression tests for issue #69.

The tests cover:

* accepting HTTPS `RPC_URL`,
* rejecting missing required `RPC_URL`,
* allowing empty optional `VERIFY_RPC_URL`,
* rejecting plaintext remote `RPC_URL`,
* rejecting plaintext remote `VERIFY_RPC_URL`,
* rejecting plaintext localhost by default,
* allowing plaintext localhost only with explicit local-development opt-in,
* rejecting plaintext remote RPC even when local opt-in is enabled,
* rejecting non-HTTP protocols,
* rejecting invalid URL syntax,
* parsing `ALLOW_INSECURE_LOCAL_RPC` only when explicitly set to `true`.

---

## Tests

Validated locally with:

* `npm run build`
* `npm test`
* `git diff --check`

Final local test result:

* `tests 102`
* `pass 102`
* `fail 0`
* `cancelled 0`
* `skipped 0`

Branch status before push:

* branch based on `upstream/main`
* one commit on top of `upstream/main`
* working tree clean before push

---

## Review Notes

The key design decision in this PR is to make HTTPS mandatory for RPC endpoints by default.

The only exception is an explicit local-development opt-in for loopback RPC endpoints. This exception is intentionally limited to localhost-style hosts and does not allow remote plaintext RPC endpoints.

This keeps production behavior secure while preserving local validator workflows.
