### PR TITLE
fix: reject zero and fractional lamport keeper balance thresholds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ HEALTH_BIND=0.0.0.0
 HEALTH_AUTH_TOKEN=your-secure-bearer-token
 MAX_PRICE_MOVE_PCT=10
 STALE_THRESHOLD_S=30
+# MIN_KEEPER_BALANCE_SOL must convert to at least 1 whole lamport after SOL -> lamports conversion; fractional-lamport values are rejected.
 MIN_KEEPER_BALANCE_SOL=0.05
 ORACLE_KEEPER_BLOCKED_MARKETS=
 

--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -60,3 +60,58 @@ export function requireProgramIdForSupabaseMode(
     );
   }
 }
+
+/**
+ * Number of lamports in one SOL.
+ */
+export const LAMPORTS_PER_SOL = 1_000_000_000;
+const LAMPORTS_PER_SOL_BIGINT = 1_000_000_000n;
+
+/**
+ * Parse a positive SOL-denominated environment variable into lamports exactly.
+ *
+ * This intentionally parses the decimal string instead of multiplying a JS
+ * floating-point number by 1e9. The keeper balance guard compares lamports at
+ * runtime, so the converted value must be a positive, safe, whole-lamport
+ * integer with no silent rounding.
+ */
+export function parsePositiveLamportsFromSolEnv(name: string, fallbackSol: number): number {
+  const raw = process.env[name];
+  const rawValue = raw == null || raw.trim() === "" ? String(fallbackSol) : raw.trim();
+
+  if (!/^(?:\d+|\d+\.\d*|\.\d+)$/.test(rawValue)) {
+    throw new Error(
+      `${name} must be a finite positive decimal SOL amount (got: ${JSON.stringify(raw)})`,
+    );
+  }
+
+  const [wholeRaw, fractionRaw = ""] = rawValue.split(".");
+  const wholePart = wholeRaw === "" ? "0" : wholeRaw;
+  const fractionPadded = fractionRaw.padEnd(9, "0");
+  const lamportFraction = fractionPadded.slice(0, 9);
+  const fractionalRemainder = fractionRaw.slice(9);
+
+  const lamports =
+    BigInt(wholePart) * LAMPORTS_PER_SOL_BIGINT +
+    BigInt(lamportFraction === "" ? "0" : lamportFraction);
+
+  if (lamports <= 0n) {
+    throw new Error(
+      `${name} must convert to at least 1 whole lamport (got: ${rawValue} SOL -> ${lamports} lamports)`,
+    );
+  }
+
+  if (/[1-9]/.test(fractionalRemainder)) {
+    throw new Error(
+      `${name} converts to a fractional lamport amount (got: ${rawValue} SOL)`,
+    );
+  }
+
+  if (lamports > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(
+      `${name} converts to an unsafe lamport amount (got: ${rawValue} SOL -> ${lamports} lamports)`,
+    );
+  }
+
+  return Number(lamports);
+}

--- a/src/env-validation.test.ts
+++ b/src/env-validation.test.ts
@@ -14,7 +14,11 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-utils.ts";
+import {
+  parsePositiveLamportsFromSolEnv,
+  parsePositiveNumberEnv,
+  requireProgramIdForSupabaseMode,
+} from "./env-utils.ts";
 
 // ── helpers ──────────────────────────────────────────────────
 
@@ -224,6 +228,119 @@ describe("requireProgramIdForSupabaseMode (issue #29)", () => {
     it("succeeds with any non-empty string (format validation is downstream)", () => {
       assert.doesNotThrow(() =>
         requireProgramIdForSupabaseMode("some-program-id"),
+      );
+    });
+  });
+});
+
+
+// ══════════════════════════════════════════════════════════════
+// #71 — MIN_KEEPER_BALANCE_SOL lamport conversion
+// ══════════════════════════════════════════════════════════════
+describe("#71 MIN_KEEPER_BALANCE_SOL lamport conversion", () => {
+  it("uses the 0.05 SOL fallback as 50,000,000 lamports when unset", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", undefined, () => {
+      assert.equal(
+        parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        50_000_000,
+      );
+    });
+  });
+
+  it("converts a normal SOL threshold into lamports", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "0.05", () => {
+      assert.equal(
+        parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        50_000_000,
+      );
+    });
+  });
+
+  it("accepts the smallest positive whole-lamport SOL value", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "0.000000001", () => {
+      assert.equal(
+        parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        1,
+      );
+    });
+  });
+
+  it("rejects a positive sub-lamport value that would round to zero", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "0.0000000004", () => {
+      assert.throws(
+        () => parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        /must convert to at least 1 whole lamport/,
+      );
+    });
+  });
+
+  it("rejects zero values", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "0", () => {
+      assert.throws(
+        () => parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        /must convert to at least 1 whole lamport/,
+      );
+    });
+  });
+
+  it("rejects negative, NaN, and Infinity values", () => {
+    for (const value of ["-1", "NaN", "Infinity"]) {
+      withEnv("MIN_KEEPER_BALANCE_SOL", value, () => {
+        assert.throws(
+          () => parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+          /finite positive decimal SOL amount/,
+        );
+      });
+    }
+  });
+
+  it("rejects values that convert to unsafe lamport integers", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "100000000000000000", () => {
+      assert.throws(
+        () => parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        /unsafe lamport amount/,
+      );
+    });
+  });
+});
+
+
+// ══════════════════════════════════════════════════════════════
+// #71 — Fractional lamport hardening
+// ══════════════════════════════════════════════════════════════
+describe("#71 MIN_KEEPER_BALANCE_SOL fractional lamport hardening", () => {
+  it("rejects a fractional sub-lamport value that would round up to one lamport", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "0.0000000005", () => {
+      assert.throws(
+        () => parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        /must convert to at least 1 whole lamport/,
+      );
+    });
+  });
+
+  it("rejects a fractional lamport value above one lamport instead of silently rounding", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "0.0000000014", () => {
+      assert.throws(
+        () => parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        /fractional lamport amount/,
+      );
+    });
+  });
+
+  it("accepts whole lamport SOL values above one lamport", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "0.000000002", () => {
+      assert.equal(
+        parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        2,
+      );
+    });
+  });
+
+  it("parses decimal SOL thresholds exactly without floating-point scaling", () => {
+    withEnv("MIN_KEEPER_BALANCE_SOL", "0.000000015", () => {
+      assert.equal(
+        parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05),
+        15,
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,11 @@ import * as http from "http";
 import * as crypto from "crypto";
 
 // ── Config ──────────────────────────────────────────────────
-import { parsePositiveNumberEnv, requireProgramIdForSupabaseMode } from "./env-utils.ts";
+import {
+  parsePositiveLamportsFromSolEnv,
+  parsePositiveNumberEnv,
+  requireProgramIdForSupabaseMode,
+} from "./env-utils.ts";
 import { checkCircuitBreaker as _checkCircuitBreaker } from "./circuit-breaker.ts";
 import type { CircuitBreakerState } from "./circuit-breaker.ts";
 
@@ -843,9 +847,10 @@ let startTime = Date.now();
 // Devops audit 2026-03-14: wallet FF7KFfU5 exhausted twice in one day from
 // ~20+ markets per 3-second cycle. Guard prevents on-chain txn drain when
 // balance is low. Default: 0.05 SOL (50_000_000 lamports).
-const MIN_KEEPER_BALANCE_LAMPORTS = process.env.MIN_KEEPER_BALANCE_SOL
-  ? Math.round(parsePositiveNumberEnv("MIN_KEEPER_BALANCE_SOL", 0.05) * 1e9)
-  : 50_000_000;
+const MIN_KEEPER_BALANCE_LAMPORTS = parsePositiveLamportsFromSolEnv(
+  "MIN_KEEPER_BALANCE_SOL",
+  0.05,
+);
 // Interval between balance refreshes (default: every 30 s = ~10 push cycles at 3s interval)
 const BALANCE_CHECK_INTERVAL_MS = parsePositiveNumberEnv("BALANCE_CHECK_INTERVAL_MS", 30000);
 let walletBalanceLamports: number | null = null;


### PR DESCRIPTION
## Summary

Closes #71.

This PR hardens `MIN_KEEPER_BALANCE_SOL` parsing so the keeper balance guard can no longer be silently configured into an ineffective zero-lamport threshold.

Previously, `MIN_KEEPER_BALANCE_SOL` was parsed as a positive SOL value and then converted to lamports using rounding. This allowed very small positive values, such as `0.0000000004`, to pass positive-number validation while converting into `0` lamports after SOL-to-lamports conversion. Once the threshold became `0` lamports, the wallet-low guard could effectively fail open because a normal non-negative wallet balance would not be lower than a zero-lamport threshold.

This PR moves validation to the actual runtime unit used by the guard: lamports. The keeper now rejects any configured SOL threshold that does not convert into a positive, safe, whole-lamport integer.

---

## Background

The keeper uses `MIN_KEEPER_BALANCE_SOL` as a wallet-balance safety threshold before pushing oracle updates. If the signer wallet balance falls below this threshold, the keeper pauses pushes to avoid continuing operation with an underfunded wallet.

The runtime guard operates in lamports:

- wallet balance is read in lamports
- minimum keeper balance is stored in lamports
- the guard compares wallet lamports against `MIN_KEEPER_BALANCE_LAMPORTS`

Because the guard uses lamports at runtime, validating only the original SOL float is not sufficient. A SOL value can be finite and positive while still converting into an invalid, fractional, unsafe, or ineffective lamport threshold.

The previous flow allowed this unsafe case:

1. Parse `MIN_KEEPER_BALANCE_SOL` as a positive number.
2. Convert SOL to lamports with `value * 1e9`.
3. Round the result.
4. Use the rounded value as `MIN_KEEPER_BALANCE_LAMPORTS`.

For sub-lamport values, this could silently produce `0` lamports.

---

## Root Cause

The root cause was validation before unit conversion.

Example:

`MIN_KEEPER_BALANCE_SOL=0.0000000004`

This value is positive, so it passes positive-number validation. However, after conversion:

`0.0000000004 SOL * 1,000,000,000 = 0.4 lamports`

With rounding, this can become:

`0 lamports`

That creates an ineffective guard threshold:

`MIN_KEEPER_BALANCE_LAMPORTS = 0`

A zero-lamport threshold defeats the purpose of the wallet-low protection because normal wallet balances are not lower than zero. This means the keeper could continue pushing when the configured balance guard was expected to pause operation.

---

## Changes

### 1. Added lamport-safe SOL parsing

This PR adds `parsePositiveLamportsFromSolEnv(...)` in `src/env-utils.ts`.

The helper validates the configured value after SOL-to-lamports conversion. It rejects unsafe configuration instead of silently rounding it.

The new parser rejects:

- zero values
- negative values
- `NaN`
- `Infinity`
- values below one lamport
- fractional lamport values
- unsafe integer lamport values

It accepts only values that convert into a positive, safe, whole-lamport integer.

This makes the wallet-balance guard deterministic and prevents unsafe configuration from being silently accepted.

### 2. Replaced direct rounding in `src/index.ts`

The previous `MIN_KEEPER_BALANCE_LAMPORTS` calculation used direct rounding after parsing `MIN_KEEPER_BALANCE_SOL`.

This PR replaces that path with the new lamport-safe parser.

The keeper now derives `MIN_KEEPER_BALANCE_LAMPORTS` through `parsePositiveLamportsFromSolEnv("MIN_KEEPER_BALANCE_SOL", 0.05)`, ensuring that the runtime guard receives a validated lamport threshold.

The default behavior remains unchanged:

`0.05 SOL = 50,000,000 lamports`

Normal production configurations continue to work as before.

### 3. Rejected fractional lamport thresholds

This PR intentionally rejects fractional lamport values instead of silently rounding them.

Rejected examples:

- `0.0000000004 SOL -> 0.4 lamports`
- `0.0000000005 SOL -> 0.5 lamports`
- `0.0000000014 SOL -> 1.4 lamports`

Accepted examples:

- `0.000000001 SOL -> 1 lamport`
- `0.000000002 SOL -> 2 lamports`
- `0.05 SOL -> 50,000,000 lamports`

This is stricter and safer for a balance guard. For safety-critical thresholds, silent rounding can make the runtime value different from what the operator intended.

### 4. Updated `.env.example`

`.env.example` now documents that `MIN_KEEPER_BALANCE_SOL` must convert to at least one whole lamport after SOL-to-lamports conversion.

This makes the requirement visible to operators and reduces the chance of accidental unsafe configuration.

---

## Security Impact

This PR strengthens the keeper wallet-balance safety guard.

Before this fix, a positive but sub-lamport `MIN_KEEPER_BALANCE_SOL` value could silently become a zero-lamport threshold. That could cause the keeper to continue pushing even when the configured balance guard was intended to pause operation.

After this fix:

- zero-lamport thresholds are rejected
- sub-lamport thresholds are rejected
- fractional lamport thresholds are rejected
- unsafe lamport values are rejected
- valid whole-lamport thresholds continue to work

The keeper now fails closed on unsafe balance-threshold configuration instead of accepting a value that weakens the wallet-low guard.

---

## Files Changed

### `src/env-utils.ts`

Adds:

- `LAMPORTS_PER_SOL`
- `parsePositiveLamportsFromSolEnv(...)`

The new parser validates the converted lamport value and ensures it is positive, finite, safe, and whole-lamport precise.

### `src/index.ts`

Updates `MIN_KEEPER_BALANCE_LAMPORTS` to use the new lamport-safe parser.

This removes the unsafe direct rounding path and ensures the runtime wallet-balance guard receives a validated lamport threshold.

### `src/env-validation.test.ts`

Adds regression tests for issue #71.

The tests cover:

- default fallback conversion to `50,000,000` lamports
- normal SOL threshold conversion
- smallest valid whole-lamport value
- rejection of positive sub-lamport values
- rejection of fractional lamport values that would otherwise be rounded
- rejection of zero, negative, `NaN`, and `Infinity`
- rejection of unsafe lamport amounts
- acceptance of valid whole-lamport values above one lamport

### `.env.example`

Documents that `MIN_KEEPER_BALANCE_SOL` must convert to at least one whole lamport.

---

## Tests

Validated locally with:

- `npm run build`
- `npm test`
- `git diff --check`

Final local test result:

- `tests 100`
- `pass 100`
- `fail 0`
- `cancelled 0`
- `skipped 0`

Branch verification before push:

- working tree clean
- branch contains one commit on top of `upstream/main`
- `git rev-list --left-right --count upstream/main...HEAD` returned `0 1`

---

## Review Notes

The main design decision in this PR is to reject invalid lamport conversions instead of silently rounding them.

For a safety-critical keeper balance threshold, the configured SOL value should map exactly to the lamport value used at runtime. Silent rounding can produce a threshold different from what the operator intended, including an ineffective zero-lamport threshold.

By validating the converted lamport value directly, this PR makes the keeper balance guard safer, stricter, and easier to reason about.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment setting handling for keeper balance limits by converting SOL values to lamports more reliably.
  * Prevented invalid, fractional, zero, or unsafe balance thresholds from being accepted, reducing unexpected pauses or misconfigurations.
  * Clarified the example environment file to note the minimum balance must convert to at least 1 lamport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->