### PR TITLE
Fix Cross-Cluster Oracle Mark Smoothing After Sample-Window Gaps

### DIFF
--- a/src/cross-cluster/keeper-loop.ts
+++ b/src/cross-cluster/keeper-loop.ts
@@ -275,6 +275,16 @@ function priceE6ToUsdNumber(priceE6: bigint): number {
   return Number(priceE6) / 1_000_000;
 }
 
+function cloneCircuitBreakerState(state: CircuitBreakerState): CircuitBreakerState {
+  return {
+    symbol: state.symbol,
+    lastPrice: state.lastPrice,
+    circuitBreakerTrips: state.circuitBreakerTrips,
+    cbTripPrice: state.cbTripPrice,
+    cbConsecutiveTrips: state.cbConsecutiveTrips,
+  };
+}
+
 // Blockhash cache — a fresh one is valid ~60-90s; refetch every 15s so each
 // cycle doesn't pay a getLatestBlockhash round-trip.
 let cachedBlockhash: { blockhash: string; lastValidBlockHeight: number } | null = null;
@@ -381,6 +391,7 @@ async function runCycle(
   // the 180s window to ~149s — undoing the widening that was deployed
   // precisely because 90s was insufficient).
   const smoothedThisCycle = new Map<string, bigint | null>();
+  const pendingCircuitBreakerStates = new Map<string, CircuitBreakerState>();
   for (const entry of registry.markets) {
     if (notPushable.has(entry.marketAddress)) continue;
     const rawPriceE6 = prices.get(entry.poolAddress);
@@ -402,23 +413,41 @@ async function runCycle(
       continue;
     }
 
-    const circuitBreakerState = getCrossClusterCircuitBreakerState(
+    const currentCircuitBreakerState = getCrossClusterCircuitBreakerState(
       entry.marketAddress,
       entry.label,
     );
+    const candidateCircuitBreakerState = cloneCircuitBreakerState(
+      currentCircuitBreakerState,
+    );
     const priceUsd = priceE6ToUsdNumber(priceE6);
-    const allowed = checkCircuitBreaker(circuitBreakerState, priceUsd, {
+    const allowed = checkCircuitBreaker(candidateCircuitBreakerState, priceUsd, {
       maxMovePct: CROSS_CLUSTER_MAX_MOVE_PCT,
       confirmTrips: CROSS_CLUSTER_CIRCUIT_BREAKER_CONFIRM_TRIPS,
       log: (msg) => console.warn(`[loop] ${msg}`),
     });
     if (!allowed) {
+      // Keep breaker trip accounting for sustained-relocation detection, but do
+      // not advance the accepted baseline. checkCircuitBreaker() does not move
+      // lastPrice on a rejected candidate.
+      crossClusterCircuitBreakerStates.set(
+        entry.marketAddress,
+        candidateCircuitBreakerState,
+      );
       stat.totalErrors++;
       stat.lastErrorMsg =
         `circuit breaker blocked mark move at ${priceUsd.toFixed(6)}`;
       continue;
     }
-    circuitBreakerState.lastPrice = priceUsd;
+
+    // The candidate is breaker-accepted, but it is not the published AuthMark
+    // yet. Stage the new baseline and commit it only after pushAuthMarkBatch
+    // confirms this market was actually pushed.
+    candidateCircuitBreakerState.lastPrice = priceUsd;
+    pendingCircuitBreakerStates.set(
+      entry.marketAddress,
+      candidateCircuitBreakerState,
+    );
 
     stat.lastPriceE6 = priceE6;
     pushes.push({ marketAddress: entry.marketAddress, assetIndex: entry.assetIndex, priceE6 });
@@ -449,6 +478,15 @@ async function runCycle(
       if (config.dryRun) {
         stat.lastSig = "DRY_RUN";
       } else if (pushedSet.has(p.marketAddress) && res.signature) {
+        const pendingCircuitBreakerState = pendingCircuitBreakerStates.get(
+          p.marketAddress,
+        );
+        if (pendingCircuitBreakerState) {
+          crossClusterCircuitBreakerStates.set(
+            p.marketAddress,
+            pendingCircuitBreakerState,
+          );
+        }
         stat.totalPushes++;
         stat.lastPushAt = stamp;
         stat.lastSig = res.signature;

--- a/src/cross-cluster/keeper-loop.ts
+++ b/src/cross-cluster/keeper-loop.ts
@@ -22,6 +22,8 @@ import type { Registry } from "./registry.ts";
 import type { DecimalsCache } from "./price-reader.ts";
 import { readAllPoolPricesE6 } from "./price-reader.ts";
 import { createMarkSmoother } from "./mark-smoother.ts";
+import { checkCircuitBreaker } from "../circuit-breaker.ts";
+import type { CircuitBreakerState } from "../circuit-breaker.ts";
 import { pushAuthMarkBatch, fetchOracleAuthority, getQuarantinedMarkets } from "./auth-mark-pusher.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -213,6 +215,66 @@ function maybeResetAuthorityLatches(): void {
  * reach the engine as oscillation. See mark-smoother.ts for the full story.
  */
 const markSmoother = createMarkSmoother();
+
+function parseCrossClusterPositiveNumberEnv(
+  name: string,
+  fallback: number,
+  maxExclusive?: number,
+): number {
+  const raw = process.env[name];
+  const value = raw === undefined || raw.trim() === "" ? fallback : Number(raw);
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a finite positive number`);
+  }
+  if (maxExclusive !== undefined && value >= maxExclusive) {
+    throw new Error(`${name} must be less than ${maxExclusive}`);
+  }
+  return value;
+}
+
+function parseCrossClusterPositiveIntegerEnv(name: string, fallback: number): number {
+  const value = parseCrossClusterPositiveNumberEnv(name, fallback);
+  if (!Number.isInteger(value)) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+const CROSS_CLUSTER_MAX_MOVE_PCT = parseCrossClusterPositiveNumberEnv(
+  "CROSS_CLUSTER_MAX_MOVE_PCT",
+  10,
+  100,
+);
+const CROSS_CLUSTER_CIRCUIT_BREAKER_CONFIRM_TRIPS = parseCrossClusterPositiveIntegerEnv(
+  "CROSS_CLUSTER_CIRCUIT_BREAKER_CONFIRM_TRIPS",
+  3,
+);
+
+const crossClusterCircuitBreakerStates = new Map<string, CircuitBreakerState>();
+
+function getCrossClusterCircuitBreakerState(
+  marketAddress: string,
+  label: string,
+): CircuitBreakerState {
+  let state = crossClusterCircuitBreakerStates.get(marketAddress);
+  if (!state) {
+    state = {
+      symbol: label,
+      lastPrice: 0,
+      circuitBreakerTrips: 0,
+      cbTripPrice: 0,
+      cbConsecutiveTrips: 0,
+    };
+    crossClusterCircuitBreakerStates.set(marketAddress, state);
+  }
+  return state;
+}
+
+function priceE6ToUsdNumber(priceE6: bigint): number {
+  return Number(priceE6) / 1_000_000;
+}
+
 // Blockhash cache — a fresh one is valid ~60-90s; refetch every 15s so each
 // cycle doesn't pay a getLatestBlockhash round-trip.
 let cachedBlockhash: { blockhash: string; lastValidBlockHeight: number } | null = null;
@@ -318,7 +380,7 @@ async function runCycle(
   // smoother's time window by N× against its MAX_SAMPLES cap (3 sharers cut
   // the 180s window to ~149s — undoing the widening that was deployed
   // precisely because 90s was insufficient).
-  const smoothedThisCycle = new Map<string, bigint>();
+  const smoothedThisCycle = new Map<string, bigint | null>();
   for (const entry of registry.markets) {
     if (notPushable.has(entry.marketAddress)) continue;
     const rawPriceE6 = prices.get(entry.poolAddress);
@@ -334,6 +396,30 @@ async function runCycle(
       priceE6 = markSmoother.smooth(entry.poolAddress, rawPriceE6, smoothNowMs);
       smoothedThisCycle.set(entry.poolAddress, priceE6);
     }
+    if (priceE6 === null) {
+      stat.totalErrors++;
+      stat.lastErrorMsg = "mark smoother re-priming — withholding push until minSamples";
+      continue;
+    }
+
+    const circuitBreakerState = getCrossClusterCircuitBreakerState(
+      entry.marketAddress,
+      entry.label,
+    );
+    const priceUsd = priceE6ToUsdNumber(priceE6);
+    const allowed = checkCircuitBreaker(circuitBreakerState, priceUsd, {
+      maxMovePct: CROSS_CLUSTER_MAX_MOVE_PCT,
+      confirmTrips: CROSS_CLUSTER_CIRCUIT_BREAKER_CONFIRM_TRIPS,
+      log: (msg) => console.warn(`[loop] ${msg}`),
+    });
+    if (!allowed) {
+      stat.totalErrors++;
+      stat.lastErrorMsg =
+        `circuit breaker blocked mark move at ${priceUsd.toFixed(6)}`;
+      continue;
+    }
+    circuitBreakerState.lastPrice = priceUsd;
+
     stat.lastPriceE6 = priceE6;
     pushes.push({ marketAddress: entry.marketAddress, assetIndex: entry.assetIndex, priceE6 });
   }

--- a/src/cross-cluster/mark-smoother.test.ts
+++ b/src/cross-cluster/mark-smoother.test.ts
@@ -177,5 +177,9 @@ describe("keeper-loop wiring", () => {
     assert.match(src, /markSmoother\.smooth\(entry\.poolAddress,\s*rawPriceE6/);
     assert.match(src, /priceE6 === null/);
     assert.match(src, /checkCircuitBreaker\(/);
+    assert.match(src, /cloneCircuitBreakerState/);
+    assert.match(src, /pendingCircuitBreakerStates/);
+    assert.match(src, /pushedSet\.has\(p\.marketAddress\) && res\.signature/);
+    assert.doesNotMatch(src, /circuitBreakerState\.lastPrice = priceUsd/);
   });
 });

--- a/src/cross-cluster/mark-smoother.test.ts
+++ b/src/cross-cluster/mark-smoother.test.ts
@@ -21,18 +21,20 @@ const T0 = 1_000_000;
 const TICK = 7_000; // the keeper's push cadence
 
 describe("createMarkSmoother", () => {
-  it("passes raw prices through until minSamples readings exist", () => {
+  it("withholds prices until minSamples readings exist", () => {
     const s = createMarkSmoother({ windowMs: 90_000, minSamples: 3 });
-    assert.equal(s.smooth(POOL, 4700n, T0), 4700n);
-    assert.equal(s.smooth(POOL, 4712n, T0 + TICK), 4712n);
+    assert.equal(s.smooth(POOL, 4700n, T0), null);
+    assert.equal(s.smooth(POOL, 4712n, T0 + TICK), null);
     // Third sample crosses the threshold: 3 is odd, so the oldest is dropped
     // and the median averages the two newest — (4712 + 4706) / 2.
     assert.equal(s.smooth(POOL, 4706n, T0 + 2 * TICK), 4709n);
   });
 
-  it("is the identity on a constant series", () => {
+  it("is the identity on a constant series after the window primes", () => {
     const s = createMarkSmoother();
-    for (let i = 0; i < 20; i++) {
+    assert.equal(s.smooth(POOL, 4643n, T0), null);
+    assert.equal(s.smooth(POOL, 4643n, T0 + TICK), null);
+    for (let i = 2; i < 20; i++) {
       assert.equal(s.smooth(POOL, 4643n, T0 + i * TICK), 4643n);
     }
   });
@@ -41,7 +43,7 @@ describe("createMarkSmoother", () => {
     const s = createMarkSmoother({ windowMs: 90_000, minSamples: 3 });
     // Real pattern observed on-chain: runs of ~4 pushes at 4643, ~2 at 4717.
     const pattern = [4643n, 4643n, 4643n, 4643n, 4717n, 4717n];
-    const out: bigint[] = [];
+    const out: Array<bigint | null> = [];
     for (let i = 0; i < 60; i++) {
       out.push(s.smooth(POOL, pattern[i % pattern.length], T0 + i * TICK));
     }
@@ -56,7 +58,7 @@ describe("createMarkSmoother", () => {
     // round-trips symmetrically is the midpoint, and CRUCIALLY the output
     // must still be STABLE, not oscillating.
     const s = createMarkSmoother({ windowMs: 90_000, minSamples: 3 });
-    const out: bigint[] = [];
+    const out: Array<bigint | null> = [];
     for (let i = 0; i < 40; i++) {
       out.push(s.smooth(POOL, i % 2 === 0 ? 4600n : 4700n, T0 + i * TICK));
     }
@@ -67,13 +69,15 @@ describe("createMarkSmoother", () => {
   it("follows a genuine sustained move with bounded lag", () => {
     const s = createMarkSmoother({ windowMs: 90_000, minSamples: 3 });
     // Flat at 4600, then a real pump: +10 per push, never retracing.
-    let last = 0n;
+    let last: bigint | null = null;
     for (let i = 0; i < 13; i++) last = s.smooth(POOL, 4600n, T0 + i * TICK);
     assert.equal(last, 4600n);
     const ramp: bigint[] = [];
     for (let i = 0; i < 26; i++) {
       const raw = 4600n + BigInt(i + 1) * 10n;
-      ramp.push(s.smooth(POOL, raw, T0 + (13 + i) * TICK));
+      const smoothed = s.smooth(POOL, raw, T0 + (13 + i) * TICK);
+      if (smoothed === null) throw new Error("smoother unexpectedly withheld after priming");
+      ramp.push(smoothed);
     }
     // Output must be monotone non-decreasing (median of a monotone window)…
     for (let i = 1; i < ramp.length; i++) assert.ok(ramp[i] >= ramp[i - 1]);
@@ -85,13 +89,35 @@ describe("createMarkSmoother", () => {
     assert.ok(lastOut > 4600n, "smoother never followed the move");
   });
 
-  it("evicts samples older than the window (an outage re-primes cleanly)", () => {
+  it("evicts samples older than the window and withholds while re-priming", () => {
     const s = createMarkSmoother({ windowMs: 90_000, minSamples: 3 });
     for (let i = 0; i < 12; i++) s.smooth(POOL, 4600n, T0 + i * TICK);
-    // 10-minute gap — everything above is stale. The first reading after the
-    // gap is alone in the window, so it must pass through raw.
+    // 10-minute gap — everything above is stale. The first readings after the
+    // gap are below minSamples, so publishing is withheld instead of raw.
     const afterGap = T0 + 12 * TICK + 600_000;
-    assert.equal(s.smooth(POOL, 5000n, afterGap), 5000n);
+    assert.equal(s.smooth(POOL, 5000n, afterGap), null);
+    assert.equal(s.smooth(POOL, 5004n, afterGap + TICK), null);
+    assert.equal(s.smooth(POOL, 5002n, afterGap + 2 * TICK), 5003n);
+  });
+
+  it("withholds the first manipulated reading after a full sample-window gap", () => {
+    const s = createMarkSmoother();
+    const fair = 1_000_000n;
+    const manip = 3_000_000n;
+    let t = T0;
+
+    for (let i = 0; i < 12; i++) {
+      assert.equal(s.smooth(POOL, fair, t), i < 2 ? null : fair);
+      t += TICK;
+    }
+
+    // Control: while the window is healthy, the median rejects a single 3x spike.
+    assert.equal(s.smooth(POOL, manip, t), fair);
+
+    // Regression for issue #93: after a full window gap, the same 3x spike must
+    // not be published raw as the mark.
+    t += 200_000;
+    assert.equal(s.smooth(POOL, manip, t), null);
   });
 
   it("keeps pools independent", () => {
@@ -130,12 +156,13 @@ describe("createMarkSmoother", () => {
     // the even-median would already sit at the midpoint — assert it doesn't.
   });
 
-  it("reset drops all state", () => {
+  it("reset drops all state and withholds until the window re-primes", () => {
     const s = createMarkSmoother({ windowMs: 90_000, minSamples: 3 });
     for (let i = 0; i < 10; i++) s.smooth(POOL, 4600n, T0 + i * TICK);
     s.reset();
-    // Below minSamples again — raw passthrough proves the window is gone.
-    assert.equal(s.smooth(POOL, 9999n, T0 + 11 * TICK), 9999n);
+    assert.equal(s.smooth(POOL, 9999n, T0 + 11 * TICK), null);
+    assert.equal(s.smooth(POOL, 10001n, T0 + 12 * TICK), null);
+    assert.equal(s.smooth(POOL, 9997n, T0 + 13 * TICK), 9999n);
   });
 });
 
@@ -148,5 +175,7 @@ describe("keeper-loop wiring", () => {
     // price before it enters the push list.
     assert.match(src, /createMarkSmoother\(/);
     assert.match(src, /markSmoother\.smooth\(entry\.poolAddress,\s*rawPriceE6/);
+    assert.match(src, /priceE6 === null/);
+    assert.match(src, /checkCircuitBreaker\(/);
   });
 });

--- a/src/cross-cluster/mark-smoother.ts
+++ b/src/cross-cluster/mark-smoother.ts
@@ -28,9 +28,10 @@
  *     excursion drags the mean), and it is not robust to a single wild
  *     outlier. The median ignores both until they hold a majority.
  *
- * Cold start / gaps: below `minSamples` readings in the window the latest raw
- * price passes through unchanged — a freshly listed market prices immediately,
- * and a long outage (window fully evicted) re-primes the same way.
+ * Cold start / gaps: below `minSamples` readings the smoother withholds the
+ * mark instead of publishing raw spot. This keeps a freshly listed market and a
+ * post-outage / post-eviction pool from using a single unfiltered reading as the
+ * settlement mark.
  */
 
 interface Sample {
@@ -41,7 +42,7 @@ interface Sample {
 export interface MarkSmootherOptions {
   /** Trailing window the median is computed over (ms). */
   windowMs?: number;
-  /** Below this many samples in the window, pass the raw price through. */
+  /** Below this many samples in the window, withhold instead of publishing raw. */
   minSamples?: number;
 }
 
@@ -61,10 +62,12 @@ const MAX_SAMPLES_PER_POOL = 64;
 
 export interface MarkSmoother {
   /**
-   * Record `priceE6` for `poolAddress` at `nowMs` and return the smoothed
-   * mark to publish this cycle.
+   * Record `priceE6` for `poolAddress` at `nowMs`.
+   *
+   * Returns the smoothed mark to publish this cycle, or `null` while the pool
+   * is still priming/re-priming and publishing would require a raw passthrough.
    */
-  smooth(poolAddress: string, priceE6: bigint, nowMs: number): bigint;
+  smooth(poolAddress: string, priceE6: bigint, nowMs: number): bigint | null;
   /** Drop every window (tests / registry rebuilds). */
   reset(): void;
 }
@@ -84,7 +87,7 @@ export function createMarkSmoother(opts: MarkSmootherOptions = {}): MarkSmoother
   const windows = new Map<string, Sample[]>();
 
   return {
-    smooth(poolAddress: string, priceE6: bigint, nowMs: number): bigint {
+    smooth(poolAddress: string, priceE6: bigint, nowMs: number): bigint | null {
       let win = windows.get(poolAddress);
       if (!win) {
         win = [];
@@ -99,7 +102,12 @@ export function createMarkSmoother(opts: MarkSmootherOptions = {}): MarkSmoother
       if (firstLive > 0) win.splice(0, firstLive);
       if (win.length > MAX_SAMPLES_PER_POOL) win.splice(0, win.length - MAX_SAMPLES_PER_POOL);
 
-      if (win.length < minSamples) return priceE6;
+      if (win.length < minSamples) {
+        // Do not publish a raw single/few-sample spot. This covers both first
+        // listing and steady-state re-prime after a liveness gap fully evicts
+        // the window.
+        return null;
+      }
       // Compute over an EVEN count (drop the single oldest sample when odd):
       // an odd-count median flips by parity under a balanced two-level
       // ping-pong (7:6 → level A, then 6:7 → level B every push) — the exact


### PR DESCRIPTION
## Summary

This PR fixes #93 by hardening the cross-cluster oracle mark pipeline against raw spot-price passthrough after a mark-smoother sample-window gap.

Previously, `createMarkSmoother()` returned the raw incoming spot price whenever a pool's trailing window contained fewer than `minSamples` readings. That behavior was originally intended for cold start, but the same condition could also be reached during steady-state runtime.

If a pool was skipped long enough for its trailing sample window to fully evict, the next valid reading could be emitted raw and then added to the cross-cluster `PushAuthMark` batch. This re-exposed the exact single-reading raw mark primitive that the median smoother was introduced to prevent.

This PR changes the behavior to fail closed:

- the smoother now withholds output while a pool is priming or re-priming;
- the cross-cluster keeper skips the push when the smoother returns `null`;
- accepted smoothed marks are routed through the existing circuit breaker before they can be added to the push batch.

Fixes #93.

---

## Root Cause

The issue came from two conditions interacting:

1. `mark-smoother.ts` allowed raw passthrough whenever `win.length < minSamples`.
2. `keeper-loop.ts` skipped pools with no valid price without appending a sample.

When a pool stayed skipped for at least the smoother window duration, the old samples aged out completely. The next valid read then re-entered the `win.length < minSamples` path and was returned raw.

Because the cross-cluster push path did not apply a circuit breaker before `pushAuthMarkBatch`, that raw mark could be placed into the push batch without a deviation backstop.

---

## What Changed

### `src/cross-cluster/mark-smoother.ts`

- Changed `smooth()` from returning `bigint` to returning `bigint | null`.
- Removed raw passthrough while the sample window is below `minSamples`.
- Returns `null` while the pool is still priming or re-priming.
- Preserves the existing median behavior once enough samples exist.
- Covers both first-seen cold start and post-gap re-prime after sample-window eviction.

This means a single fresh reading is no longer enough to become the settlement mark.

### `src/cross-cluster/keeper-loop.ts`

- Handles `null` smoother output by withholding the push for that market.
- Adds cross-cluster circuit-breaker enforcement before a mark is added to the push batch.
- Tracks per-market circuit-breaker state.
- Adds configurable cross-cluster bounds:
  - `CROSS_CLUSTER_MAX_MOVE_PCT`, default `10`, bounded below `100`
  - `CROSS_CLUSTER_CIRCUIT_BREAKER_CONFIRM_TRIPS`, default `3`
- Only pushes a mark after:
  1. the smoother has enough samples, and
  2. the circuit breaker accepts the smoothed mark.

This keeps the cross-cluster AuthMark path aligned with the defense-in-depth expectations already present in the standalone keeper path.

### `src/cross-cluster/mark-smoother.test.ts`

Updated and added regression coverage for:

- withholding prices until `minSamples` readings exist;
- preserving constant-series identity after the window primes;
- preserving the CATE two-level ping-pong median behavior;
- preserving balanced ping-pong midpoint behavior;
- following sustained moves with bounded lag;
- withholding after full sample-window eviction;
- preventing the first manipulated post-gap reading from being published raw;
- preserving pool independence;
- preserving single-outlier resistance;
- preserving the default 180s window behavior;
- reset/re-prime behavior;
- keeper-loop wiring for `null` handling and circuit-breaker enforcement.

---

## Security Impact

This closes the raw post-gap oracle mark passthrough described in #93.

A manipulated single spot reading after a long liveness gap is no longer eligible to become the settlement mark. Instead, the keeper withholds the market push until the smoother re-primes. Once a smoothed mark is available, it must still pass the cross-cluster circuit breaker before it can be included in `pushAuthMarkBatch`.

The vulnerable path changes from:

~~~text
post-gap single raw spot
  -> smoother raw passthrough
  -> cross-cluster push batch
~~~

to:

~~~text
post-gap single raw spot
  -> smoother returns null
  -> push withheld
~~~

and once re-primed:

~~~text
smoothed mark
  -> circuit breaker
  -> cross-cluster push batch
~~~

---

## Validation

Ran locally:

~~~bash
node --import tsx/esm --test src/cross-cluster/mark-smoother.test.ts
npm run build
git diff --check
npm test
~~~

Results:

~~~text
src/cross-cluster/mark-smoother.test.ts: 12/12 passing
full test suite: 191/191 passing
build: tsc --noEmit clean
diff check: clean
~~~

The full test suite passed after installing/building the local sibling `percolator-sdk` dependency required by this repository's local test setup.

---

## Notes

The smoother now intentionally withholds during first prime and post-gap re-prime instead of publishing raw spot. This slightly delays publication for a newly seen or re-priming pool until `minSamples` is reached, but avoids using a single unfiltered reading as a settlement mark.

That tradeoff is intentional for this security-critical mark pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added circuit-breaker protection for cross-cluster price updates.
  * Configurable limits help prevent excessive price movements and require confirmation before changes are accepted.
* **Bug Fixes**
  * Prices are now withheld during startup or re-prime periods until enough readings are available.
  * Stale data resets correctly require the smoother to gather fresh samples before publishing a price.
  * Blocked price movements are no longer submitted and are recorded as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->